### PR TITLE
added travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# adapted from https://github.com/andysworkshop/stm32plus/blob/master/.travis.yml
+
+language: c
+sudo: false
+
+addons:
+  apt:
+    packages:
+      libc6-i386
+
+cache:
+  directories:
+    - $HOME/dl
+
+install:
+  - export GCC_DIR=$HOME/dl/gcc-arm-none-eabi-5_2-2015q4
+  - export GCC_ARCHIVE=$HOME/dl/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
+  - export GCC_URL=https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
+  - if [ ! -e $GCC_DIR/bin/arm-none-eabi-gcc ]; then wget $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME/dl; fi
+  - export PATH=$PATH:$GCC_DIR/bin
+
+script:
+  - make clean && make


### PR DESCRIPTION
Added continuous integration with `travis-ci`. You will need to register this repo on https://travis-ci.org/.

Working on my repo https://travis-ci.org/nickaknudson/ODriveFirmware