### PR TITLE
Handle current scaling factor for HW versions <= 3.3

### DIFF
--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -421,7 +421,7 @@ static void DRV8301_setup(Motor_t* motor) {
 
         float margin = 0.95f;
         float max_input = margin * 0.3f * motor->shunt_conductance;
-        float max_swing = margin * 1.6f * motor->shunt_conductance / motor->phase_current_rev_gain;
+        float max_swing = margin * 1.6f * motor->shunt_conductance * motor->phase_current_rev_gain;
         motor->max_allowed_current = MACRO_MIN(max_input, max_swing);
 
         local_regs->SndCmd = true;

--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -1309,7 +1309,7 @@ static void control_motor_loop(Motor_t* motor) {
         }
 
         // Current limiting
-        float Ilim = motor->current_control.current_lim;
+        float Ilim = MACRO_MIN(motor->current_control.current_lim, motor->max_allowed_current);
         bool limited = false;
         if (Iq > Ilim) {
             limited = true;

--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -39,8 +39,6 @@ float vbus_voltage = 12.0f;
 #define POLE_PAIRS 7
 static float elec_rad_per_enc = POLE_PAIRS * 2 * M_PI * (1.0f / (float)ENCODER_CPR);
 
-#define CURRENT_SCALING_FACTOR (1.31578947f)
-
 // TODO: Migrate to C++, clearly we are actually doing object oriented code here...
 // TODO: For nice encapsulation, consider not having the motor objects public
 Motor_t motors[] = {
@@ -621,12 +619,7 @@ void pwm_trig_adc_cb(ADC_HandleTypeDef* hadc, bool injected) {
     } else {
         ADCValue = HAL_ADC_GetValue(hadc);
     }
-    if(HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR <= 3){
-        float current = phase_current_from_adcval(motor, ADCValue)*CURRENT_SCALING_FACTOR;
-    } else {
-        float current = phase_current_from_adcval(motor, ADCValue);
-    }
-    
+    float current = phase_current_from_adcval(motor, ADCValue);
 
     if (current_meas_not_DC_CAL) {
         // ADC2 and ADC3 record the phB and phC currents concurrently,
@@ -1300,12 +1293,7 @@ static void control_motor_loop(Motor_t* motor) {
         }
 
         // Current limiting
-        if(HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR <= 3){
-            float Ilim = motor->current_control.current_lim*CURRENT_SCALING_FACTOR;
-        } else{
-            float Ilim = motor->current_control.current_lim;
-        }
-        
+        float Ilim = motor->current_control.current_lim;
         bool limited = false;
         if (Iq > Ilim) {
             limited = true;

--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -39,6 +39,14 @@ float vbus_voltage = 12.0f;
 #define POLE_PAIRS 7
 static float elec_rad_per_enc = POLE_PAIRS * 2 * M_PI * (1.0f / (float)ENCODER_CPR);
 
+#if HW_VERSION_MAJOR == 3
+    #if HW_VERSION_MINOR < 4
+        #define SHUNT_RESISTANCE (666e-6)
+    #else
+        #define SHUNT_RESISTANCE (500e-6)
+    #endif
+#endif
+
 // TODO: Migrate to C++, clearly we are actually doing object oriented code here...
 // TODO: For nice encapsulation, consider not having the motor objects public
 Motor_t motors[] = {
@@ -83,7 +91,7 @@ Motor_t motors[] = {
             .enableTimeOut = false,
         },
         // .gate_driver_regs Init by DRV8301_setup
-        .shunt_conductance = 1.0f/0.0005f, //[S]
+        .shunt_conductance = 1.0f/SHUNT_RESISTANCE, //[S]
         .phase_current_rev_gain = 0.0f, // to be set by DRV8301_setup
         .current_control = {
             // .current_lim = 75.0f, //[A] // If setting higher than 75A, you MUST change DRV8301_ShuntAmpGain. TODO: make this automatic
@@ -175,7 +183,7 @@ Motor_t motors[] = {
             .enableTimeOut = false,
         },
         // .gate_driver_regs Init by DRV8301_setup
-        .shunt_conductance = 1.0f/0.0005f, //[S]
+        .shunt_conductance = 1.0f/SHUNT_RESISTANCE, //[S]
         .phase_current_rev_gain = 0.0f, // to be set by DRV8301_setup
         .current_control = {
             // .current_lim = 75.0f, //[A] // If setting higher than 75A, you MUST change DRV8301_ShuntAmpGain. TODO: make this automatic

--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -39,6 +39,8 @@ float vbus_voltage = 12.0f;
 #define POLE_PAIRS 7
 static float elec_rad_per_enc = POLE_PAIRS * 2 * M_PI * (1.0f / (float)ENCODER_CPR);
 
+#define CURRENT_SCALING_FACTOR (1.31578947f)
+
 // TODO: Migrate to C++, clearly we are actually doing object oriented code here...
 // TODO: For nice encapsulation, consider not having the motor objects public
 Motor_t motors[] = {
@@ -619,7 +621,12 @@ void pwm_trig_adc_cb(ADC_HandleTypeDef* hadc, bool injected) {
     } else {
         ADCValue = HAL_ADC_GetValue(hadc);
     }
-    float current = phase_current_from_adcval(motor, ADCValue);
+    if(HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR <= 3){
+        float current = phase_current_from_adcval(motor, ADCValue)*CURRENT_SCALING_FACTOR;
+    } else {
+        float current = phase_current_from_adcval(motor, ADCValue);
+    }
+    
 
     if (current_meas_not_DC_CAL) {
         // ADC2 and ADC3 record the phB and phC currents concurrently,
@@ -1293,7 +1300,12 @@ static void control_motor_loop(Motor_t* motor) {
         }
 
         // Current limiting
-        float Ilim = motor->current_control.current_lim;
+        if(HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR <= 3){
+            float Ilim = motor->current_control.current_lim*CURRENT_SCALING_FACTOR;
+        } else{
+            float Ilim = motor->current_control.current_lim;
+        }
+        
         bool limited = false;
         if (Iq > Ilim) {
             limited = true;

--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -104,6 +104,7 @@ Motor_t motors[] = {
             .final_v_alpha = 0.0f,
             .final_v_beta = 0.0f,
             .Iq = 0.0f,
+            .max_allowed_current = 0.0f,
         },
         // .rotor_mode = ROTOR_MODE_SENSORLESS,
         // .rotor_mode = ROTOR_MODE_RUN_ENCODER_TEST_SENSORLESS,
@@ -144,7 +145,6 @@ Motor_t motors[] = {
             .calib_pos_threshold = 1.0f,
             .calib_vel_threshold = 1.0f,
         },
-        .max_allowed_current = 0.0f,
     },
     {   // M1
         .control_mode = CTRL_MODE_POSITION_CONTROL, //see: Motor_control_mode_t
@@ -197,6 +197,7 @@ Motor_t motors[] = {
             .final_v_alpha = 0.0f,
             .final_v_beta = 0.0f,
             .Iq = 0.0f,
+            .max_allowed_current = 0.0f,
         },
         .rotor_mode = ROTOR_MODE_ENCODER,
         .encoder = {
@@ -234,8 +235,7 @@ Motor_t motors[] = {
             .calib_anticogging = false,
             .calib_pos_threshold = 1.0f,
             .calib_vel_threshold = 1.0f,
-        },
-        .max_allowed_current = 0.0f,
+        }
     }
 };
 const int num_motors = sizeof(motors)/sizeof(motors[0]);
@@ -422,7 +422,7 @@ static void DRV8301_setup(Motor_t* motor) {
         float margin = 0.95f;
         float max_input = margin * 0.3f * motor->shunt_conductance;
         float max_swing = margin * 1.6f * motor->shunt_conductance * motor->phase_current_rev_gain;
-        motor->max_allowed_current = MACRO_MIN(max_input, max_swing);
+        motor->current_control.max_allowed_current = MACRO_MIN(max_input, max_swing);
 
         local_regs->SndCmd = true;
         DRV8301_writeData(gate_driver, local_regs);
@@ -1309,7 +1309,7 @@ static void control_motor_loop(Motor_t* motor) {
         }
 
         // Current limiting
-        float Ilim = MACRO_MIN(motor->current_control.current_lim, motor->max_allowed_current);
+        float Ilim = MACRO_MIN(motor->current_control.current_lim, motor->current_control.max_allowed_current);
         bool limited = false;
         if (Iq > Ilim) {
             limited = true;

--- a/Firmware/MotorControl/low_level.h
+++ b/Firmware/MotorControl/low_level.h
@@ -71,6 +71,7 @@ typedef struct {
     float final_v_alpha; // [V]
     float final_v_beta; // [V]
     float Iq;
+    float max_allowed_current;
 } Current_control_t;
 
 typedef enum {
@@ -146,7 +147,6 @@ typedef struct {
     int timing_log_index;
     uint16_t timing_log[TIMING_LOG_SIZE];
     Anticogging_t anticogging;
-    float max_allowed_current;
 } Motor_t;
 
 typedef struct{

--- a/Firmware/MotorControl/low_level.h
+++ b/Firmware/MotorControl/low_level.h
@@ -146,6 +146,7 @@ typedef struct {
     int timing_log_index;
     uint16_t timing_log[TIMING_LOG_SIZE];
     Anticogging_t anticogging;
+    float max_allowed_current;
 } Motor_t;
 
 typedef struct{

--- a/Firmware/MotorControl/utils.h
+++ b/Firmware/MotorControl/utils.h
@@ -70,6 +70,7 @@
 
 #define MACRO_MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MACRO_MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MACRO_CONSTRAIN(amt,low,high) (((amt)<(low)) ? (low) : ((amt > high) ? (high) : (amt)))
 
 // Compute rising edge timings (0.0 - 1.0) as a function of alpha-beta
 // as per the magnitude invariant clarke transform

--- a/Firmware/MotorControl/utils.h
+++ b/Firmware/MotorControl/utils.h
@@ -70,7 +70,6 @@
 
 #define MACRO_MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MACRO_MIN(x, y) (((x) < (y)) ? (x) : (y))
-#define MACRO_CONSTRAIN(amt,low,high) (((amt)<(low)) ? (low) : ((amt > high) ? (high) : (amt)))
 
 // Compute rising edge timings (0.0 - 1.0) as a function of alpha-beta
 // as per the magnitude invariant clarke transform


### PR DESCRIPTION
Addresses #69 - invisibly handles the current scaling, so users can still assume < 75A (if shunt resistor values are unchanged)