### PR TITLE
Switch over to the Cortex-Debug extension for VSCode

### DIFF
--- a/Firmware/.vscode/launch.json
+++ b/Firmware/.vscode/launch.json
@@ -9,7 +9,6 @@
             "type": "openocd-gdb",
             "request": "launch",
             "name": "Debug Microcontroller",
-            "gdbpath": "arm-none-eabi-gdb",
             "executable": "${workspaceRoot}/build/ODriveFirmware.elf",
             "configFiles": [
                 "interface/stlink-v2.cfg",

--- a/Firmware/.vscode/launch.json
+++ b/Firmware/.vscode/launch.json
@@ -5,6 +5,20 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // For the Cortex-Debug extension
+            "type": "openocd-gdb",
+            "request": "launch",
+            "name": "Debug Microcontroller",
+            "gdbpath": "arm-none-eabi-gdb",
+            "executable": "${workspaceRoot}/build/ODriveFirmware.elf",
+            "configFiles": [
+                "interface/stlink-v2.cfg",
+                "target/stm32f4x_stlink.cfg",
+            ],
+            "cwd": "${workspaceRoot}"
+        },
+        // For the Native Debug extension
+        {
             "type": "gdb",
             "request": "attach",
             "name": "Debug Firmware",
@@ -14,7 +28,6 @@
             "executable": "./build/ODriveFirmware.elf",
             "cwd": "${workspaceRoot}",
             "printCalls": false,
-            //"preLaunchTask": "openocd",  // This isn't working quite right.
             "autorun": [
                 "monitor reset halt"
             ]

--- a/Firmware/.vscode/launch.json
+++ b/Firmware/.vscode/launch.json
@@ -17,20 +17,5 @@
             ],
             "cwd": "${workspaceRoot}"
         },
-        // For the Native Debug extension
-        {
-            "type": "gdb",
-            "request": "attach",
-            "name": "Debug Firmware",
-            "target": "localhost:3333",
-            "gdbpath": "arm-none-eabi-gdb",
-            "remote": true,
-            "executable": "./build/ODriveFirmware.elf",
-            "cwd": "${workspaceRoot}",
-            "printCalls": false,
-            "autorun": [
-                "monitor reset halt"
-            ]
-        }
     ]
 }

--- a/Firmware/.vscode/launch.json
+++ b/Firmware/.vscode/launch.json
@@ -8,7 +8,7 @@
             // For the Cortex-Debug extension
             "type": "openocd-gdb",
             "request": "launch",
-            "name": "Debug Microcontroller",
+            "name": "Debug ODrive",
             "executable": "${workspaceRoot}/build/ODriveFirmware.elf",
             "configFiles": [
                 "interface/stlink-v2.cfg",


### PR DESCRIPTION
Much better debugging of ARM Cortex devices.  Launches/closes OpenOCD at the appropriate times.  More info here

https://www.reddit.com/r/embedded/comments/7q1hri/visual_studio_code_extension_for_debugging_arm/dsm2gmj/