### PR TITLE
Feature/cpr check

### DIFF
--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -793,9 +793,9 @@ bool calib_enc_offset(Motor_t* motor, float voltage_magnitude) {
         encvaluesum += (int16_t)motor->encoder.encoder_timer->Instance->CNT;
     }
 
-    float estEnc = scan_range / elec_rad_per_enc;
-    float adjustedCount = fabsf((int16_t)motor->encoder.encoder_timer->Instance->CNT)-init_enc_val;
-    if(fabsf(adjustedCount-estEnc)/estEnc > motor->encoder.encoder_calib_range)
+    float expected_encoder_delta = scan_range / elec_rad_per_enc;
+    float actual_encoder_delta_abs = fabsf((int16_t)motor->encoder.encoder_timer->Instance->CNT-init_enc_val);
+    if(fabsf(actual_encoder_delta_abs - expected_encoder_delta)/expected_encoder_delta > motor->encoder.encoder_calib_range)
     {
         motor->error = ERROR_ENCODER_CPR_OUT_OF_RANGE;
         return false;

--- a/Firmware/MotorControl/low_level.c
+++ b/Firmware/MotorControl/low_level.c
@@ -762,9 +762,9 @@ bool measure_phase_inductance(Motor_t* motor, float voltage_low, float voltage_h
 // TODO: add check_timing
 bool calib_enc_offset(Motor_t* motor, float voltage_magnitude) {
     static const float start_lock_duration = 1.0f;
-    static const int num_steps = 1024;
+    static const int num_steps = 1024*4;
     static const float dt_step = 1.0f / 500.0f;
-    static const float scan_range = 4.0f * M_PI;
+    static const float scan_range = 16.0f * M_PI;
     const float step_size = scan_range / (float)num_steps;  // TODO handle const expressions better (maybe switch to C++ ?)
 
     // go to motor zero phase for start_lock_duration to get ready to scan

--- a/Firmware/MotorControl/low_level.h
+++ b/Firmware/MotorControl/low_level.h
@@ -50,6 +50,7 @@ typedef enum {
     ERROR_SPIN_UP_TIMEOUT,
     ERROR_DRV_FAULT,
     ERROR_NOT_IMPLEMENTED_MOTOR_TYPE,
+    ERROR_ENCODER_CPR_OUT_OF_RANGE
 } Error_t;
 
 // Note: these should be sorted from lowest level of control to
@@ -119,6 +120,7 @@ typedef struct {
     int32_t encoder_offset;
     int32_t encoder_state;
     int32_t motor_dir;  // 1/-1 for fwd/rev alignment to encoder.
+    float encoder_calib_range;
     float phase;
     float pll_pos;
     float pll_vel;


### PR DESCRIPTION
Checks the encoders during calibration to try to give the user a head's up if they've got the wrong encoder CPR set.  Default threshold is 2% deviation from expected.