### PR TITLE
Random fixes

### DIFF
--- a/Firmware/.vscode/c_cpp_properties.json
+++ b/Firmware/.vscode/c_cpp_properties.json
@@ -25,26 +25,7 @@
                 "_DEBUG",
                 "UNICODE"
             ],
-            "intelliSenseMode": "clang-x64",
-            "browse": {
-                "path": [
-                    "${workspaceRoot}",
-                    "${workspaceRoot}/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F",
-                    "${workspaceRoot}/Middlewares/Third_Party/FreeRTOS/Source/include",
-                    "${workspaceRoot}/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS",
-                    "${workspaceRoot}/Drivers/DRV8301",
-                    "${workspaceRoot}/Middlewares/ST/STM32_USB_Device_Library/Core/Inc",
-                    "${workspaceRoot}/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc",
-                    "${workspaceRoot}/Drivers/STM32F4xx_HAL_Driver/Inc",
-                    "${workspaceRoot}/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy",
-                    "${workspaceRoot}/Drivers/CMSIS/Device/ST/STM32F4xx/Include",
-                    "${workspaceRoot}/Drivers/CMSIS/Include",
-                    "${workspaceRoot}/Inc",
-                    "${workspaceRoot}/MotorControl"
-                ],
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": ""
-            }
+            "intelliSenseMode": "clang-x64"
         },
         {
             "name": "Linux",

--- a/Firmware/.vscode/c_cpp_properties.json
+++ b/Firmware/.vscode/c_cpp_properties.json
@@ -25,6 +25,14 @@
                 "_DEBUG",
                 "UNICODE"
             ],
+            "browse": {
+                "path": [
+                    "C:/Program Files (x86)/GNU Tools ARM Embedded/6 2017-q1-update/",
+                    "${workspaceRoot}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
             "intelliSenseMode": "clang-x64"
         },
         {

--- a/Firmware/.vscode/settings.json
+++ b/Firmware/.vscode/settings.json
@@ -3,7 +3,8 @@
     "files.exclude": {
         "build": true
     },
-    "C_Cpp.intelliSenseEngineFallback": "Disabled",
+    "C_Cpp.intelliSenseEngineFallback": "Enabled",
+    "C_Cpp.intelliSenseEngine": "Tag Parser",
     "files.associations": {
         "memory": "cpp",
         "utility": "cpp",

--- a/Firmware/.vscode/settings.json
+++ b/Firmware/.vscode/settings.json
@@ -3,6 +3,7 @@
     "files.exclude": {
         "build": true
     },
+    "C_Cpp.intelliSenseEngineFallback": "Disabled",
     "files.associations": {
         "memory": "cpp",
         "utility": "cpp",

--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -130,8 +130,8 @@ CFLAGS += -g -gdwarf-2
 CXXFLAGS += -g -gdwarf-2
 endif
 # Generate dependency information
-CFLAGS += -std=c99 -MD -MP -MF .dep/$(@F).d
-CXXFLAGS += -std=c++14 -MD -MP -MF .dep/$(@F).d
+CFLAGS += -std=gnu99 -MD -MP -MF .dep/$(@F).d
+CXXFLAGS += -std=gnu++14 -MD -MP -MF .dep/$(@F).d
 
 #######################################
 # LDFLAGS

--- a/Firmware/MotorControl/utils.h
+++ b/Firmware/MotorControl/utils.h
@@ -70,9 +70,10 @@ extern "C" {
  */
 #define STM_ID_GetUUID(x) ((x >= 0 && x < 3) ? (*(uint32_t *)(ID_UNIQUE_ADDRESS + 4 * (x))) : 0)
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846f
+#ifdef M_PI
+#undef M_PI
 #endif
+#define M_PI 3.14159265358979323846f
 
 #define MACRO_MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MACRO_MIN(x, y) (((x) < (y)) ? (x) : (y))


### PR DESCRIPTION
* Make M_PI a float literal (if utils.h is included)
* Allow gnu extensions
* Use the tag parser & fix the paths - no more uint32_t not a type error!