### PR TITLE
Add usbpermission command script

### DIFF
--- a/usbpermission
+++ b/usbpermission
@@ -1,0 +1,1 @@
+sudo udevadm control --reload-rules && sudo service udev restart && sudo udevadm trigger


### PR DESCRIPTION
This is a single command line script to easy first users changing usb device /dev/ttyACM0 permissions, and run the demos. 