### PR TITLE
Ensure sane config if config CRC16 mismatches

### DIFF
--- a/Firmware/MotorControl/config.cpp
+++ b/Firmware/MotorControl/config.cpp
@@ -222,6 +222,11 @@ void init_configuration(void) {
         // motor_config[0] = MotorConfig_t();
         // motor_config[1] = MotorConfig_t();
 
+        // TODO: temporary hack, this is gonna change after refactoring
+        axis_configs[0] = AxisConfig();
+        axis_configs[1] = AxisConfig();
+        brake_resistance = 0.47f;
+
         // Default config coming from flashed Motor_t
         return;
     } else {


### PR DESCRIPTION
axis_config and brake_resistor was not initialized correctly if the NVM load fails due to a change in config data length or version