### PR TITLE
Add `make erase_config`

### DIFF
--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -4,6 +4,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 ### Added
 * **Storing of configuration parameters to Non Volatile Memory**
 * **USB Bootloader**
+* `make erase_config` to erase the configuration with an STLink (the configuration can also be erased from within explore_odrive.py, using `my_odrive.erase_configuration()`)
 
 ### Changed
 * The build is now configured using the `tup.config` file instead of editing source files. Make sure you set your board version correctly. See [here](README.md#configuring-the-build) for details.

--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -24,8 +24,12 @@ bmp: all
 		--ex 'attach 1' \
 		--ex 'load' $(FIRMWARE)
 
+# Erase all configuration from the ODrive
+erase_config:
+	openocd -f interface/stlink-v2.cfg -f target/stm32f4x.cfg -c init -c reset\ halt -c flash\ erase_address\ 0x80C0000\ 0x40000 -c reset\ run -c exit
+
 clean:
 	-rm -fR .dep $(BUILD_DIR)
 
-.PHONY: all flash gdb dfu bmp clean
+.PHONY: all flash gdb dfu bmp clean erase_config
 


### PR DESCRIPTION
This allows developers to erase the entire configuration
without relying on the device to be reachable over USB.