### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,12 @@ env:
 
 script:
   - ./tools/build.sh
+
+deploy:
+  provider: releases
+  api_key: "GITHUB OAUTH TOKEN"
+  file: Firmware/deploy/*
+  skip_cleanup: true
+  on:
+    branch: master
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,16 @@ install:
   - if [ ! -e $TUP_DIR/bin/tup ]; then wget $TUP_URL -O $TUP_ARCHIVE; dpkg-deb -R $TUP_ARCHIVE $TUP_DIR; fi
   - export PATH=$PATH:$TUP_DIR/usr/bin
 
+env:
+  # Build default configuration for each board
+  - "CONFIG_BOARD_VERSION=v3.2 DEPLOY=v3.2"
+  - "CONFIG_BOARD_VERSION=v3.3 DEPLOY=v3.3"
+  - "CONFIG_BOARD_VERSION=v3.4-24V DEPLOY=v3.4-24V"
+  - "CONFIG_BOARD_VERSION=v3.4-48V DEPLOY=v3.4-48V"
+
+  # Various protocol combinations  
+  - "CONFIG_BOARD_VERSION=v3.4-24V CONFIG_USB_PROTOCOL=native-stream CONFIG_UART_PROTOCOL=native"
+  - "CONFIG_BOARD_VERSION=v3.4-24V CONFIG_USB_PROTOCOL=none CONFIG_UART_PROTOCOL=none"
+
 script:
-  - cd Firmware
-  - mkdir -p build
-  - echo "CONFIG_BOARD_VERSION=v3.4-24V" > tup.config # TODO: build more configuration combinations
-  - tup generate ./build.sh
-  - bash -xe ./build.sh
+  - ./tools/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # adapted from https://github.com/andysworkshop/stm32plus/blob/master/.travis.yml
 
 branches:
-  only: 
-    - master
-    - devel
+  only:
+  - master
+  - devel
 
 language: c
 sudo: false
@@ -15,39 +15,40 @@ addons:
 
 cache:
   directories:
-    - $HOME/dl
+  - "$HOME/dl"
 
 install:
-  - export GCC_DIR=$HOME/dl/gcc-arm-none-eabi-5_2-2015q4
-  - export GCC_ARCHIVE=$HOME/dl/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
-  - export GCC_URL=https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
-  - if [ ! -e $GCC_DIR/bin/arm-none-eabi-gcc ]; then wget $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME/dl; fi
-  - export PATH=$PATH:$GCC_DIR/bin
-  - export TUP_DIR=$HOME/dl/tup_0.7.5-0~16.04.york0_amd64
-  - export TUP_ARCHIVE=$HOME/dl/tup_0.7.5-0~16.04.york0_amd64.deb
-  - export TUP_URL=http://ppa.launchpad.net/jonathonf/tup/ubuntu/pool/main/t/tup/tup_0.7.5-0~16.04.york0_amd64.deb
-  - if [ ! -e $TUP_DIR/bin/tup ]; then wget $TUP_URL -O $TUP_ARCHIVE; dpkg-deb -R $TUP_ARCHIVE $TUP_DIR; fi
-  - export PATH=$PATH:$TUP_DIR/usr/bin
+- export GCC_DIR=$HOME/dl/gcc-arm-none-eabi-5_2-2015q4
+- export GCC_ARCHIVE=$HOME/dl/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
+- export GCC_URL=https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
+- if [ ! -e $GCC_DIR/bin/arm-none-eabi-gcc ]; then wget $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME/dl; fi
+- export PATH=$PATH:$GCC_DIR/bin
+- export TUP_DIR=$HOME/dl/tup_0.7.5-0~16.04.york0_amd64
+- export TUP_ARCHIVE=$HOME/dl/tup_0.7.5-0~16.04.york0_amd64.deb
+- export TUP_URL=http://ppa.launchpad.net/jonathonf/tup/ubuntu/pool/main/t/tup/tup_0.7.5-0~16.04.york0_amd64.deb
+- if [ ! -e $TUP_DIR/bin/tup ]; then wget $TUP_URL -O $TUP_ARCHIVE; dpkg-deb -R $TUP_ARCHIVE $TUP_DIR; fi
+- export PATH=$PATH:$TUP_DIR/usr/bin
 
 env:
   # Build default configuration for each board
-  - "CONFIG_BOARD_VERSION=v3.2 DEPLOY=v3.2"
-  - "CONFIG_BOARD_VERSION=v3.3 DEPLOY=v3.3"
-  - "CONFIG_BOARD_VERSION=v3.4-24V DEPLOY=v3.4-24V"
-  - "CONFIG_BOARD_VERSION=v3.4-48V DEPLOY=v3.4-48V"
+  - CONFIG_BOARD_VERSION=v3.2 DEPLOY=v3.2
+  - CONFIG_BOARD_VERSION=v3.3 DEPLOY=v3.3
+  - CONFIG_BOARD_VERSION=v3.4-24V DEPLOY=v3.4-24V
+  - CONFIG_BOARD_VERSION=v3.4-48V DEPLOY=v3.4-48V
 
-  # Various protocol combinations  
-  - "CONFIG_BOARD_VERSION=v3.4-24V CONFIG_USB_PROTOCOL=native-stream CONFIG_UART_PROTOCOL=native"
-  - "CONFIG_BOARD_VERSION=v3.4-24V CONFIG_USB_PROTOCOL=none CONFIG_UART_PROTOCOL=none"
+  # Various protocol combinations
+  - CONFIG_BOARD_VERSION=v3.4-24V CONFIG_USB_PROTOCOL=native-stream CONFIG_UART_PROTOCOL=native
+  - CONFIG_BOARD_VERSION=v3.4-24V CONFIG_USB_PROTOCOL=none CONFIG_UART_PROTOCOL=none
 
 script:
-  - ./tools/build.sh
+- "./tools/build.sh"
 
 deploy:
   provider: releases
-  api_key: "GITHUB OAUTH TOKEN"
+  api_key:
+    secure: RM66joGTn11Z5PmG7Nlj8cRcVY0w7ga5qUl2ahinbDm6jMV8OxroaXKivEa478alx9fygMHVeKdJZUlrAkRJ5OYJ1trfpW+43S3OYEnfy1nyXEXRwhgeIlb9LqdrumXVAp7TZ0Vppfom8A2ZWbxKxW3lG/EAmA4G9fnxHf0S9rF0y95YVfGrxdapTKcxvbP7Yojo53474ZI6+VYrqx8lq0JAnn4FwNT9ZJ1QASrmIw4w08f60XXv25BzndCTscvLb2qUu0AaGLbQUosde0Bb7P+aQsBVY6uSkg9MWV8gWPQjtO3u5IRR1bTshxf2kPqtzwK+SpcYrddoGN6BkKAB3lVorJIW5VguUkRmtPZ1K9+NhIztNevB2qr0ASutumNLF3aqMt19KL3A+SRx6froj5VhRHf4i/Xjm3SDLTaTcc8ZIh2PEE6scUMUMs5Mzu8LQWjInRe25MSb+pQB1mNOHmoFBtVb0J3u7Nvs8jdImN5gQWvvowWXfXRNE0ncT1YsLmevwi3q+YdEjpAIPnrD/rouY8WaqQZ/vE15JM9uwdQRqKAbzGtMaKHDk7EZ7ANTyaP+UrQ/M5cVDa0bWsWSvqSqDJMy4IVHRlirYA/5u74lXNhmA8DGDB/gFVlVCmoEzas/pnYiAE1hh4RpsYxts78Ix+wbeo1hmt7t65X8cyo=
   file: Firmware/deploy/*
-  skip_cleanup: true
   on:
+    repo: madcowswe/ODrive
     branch: master
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
   - CONFIG_BOARD_VERSION=v3.4-24V CONFIG_USB_PROTOCOL=none CONFIG_UART_PROTOCOL=none
 
 script:
-- "./tools/build.sh"
+- "./Firmware/build.sh"
 
 deploy:
   provider: releases

--- a/Firmware/.gitignore
+++ b/Firmware/.gitignore
@@ -3,6 +3,7 @@
 build/
 deploy/
 .dep/
+tup_build.sh
 
 #markdown preview output
 README.html

--- a/Firmware/.gitignore
+++ b/Firmware/.gitignore
@@ -1,6 +1,7 @@
 
 #build folder
 build/
+deploy/
 .dep/
 
 #markdown preview output

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 * **Storing of configuration parameters to Non Volatile Memory**
 * **USB Bootloader**
 * `make erase_config` to erase the configuration with an STLink (the configuration can also be erased from within explore_odrive.py, using `my_odrive.erase_configuration()`)
+* Travis-CI builds firmware for all board versions and deploys the binaries when a tag is pushed to master
 
 ### Changed
 * The build is now configured using the `tup.config` file instead of editing source files. Make sure you set your board version correctly. See [here](README.md#configuring-the-build) for details.

--- a/Firmware/build.sh
+++ b/Firmware/build.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 THIS_DIR="$(dirname "$0")"
-cd "$THIS_DIR/../Firmware"
+cd "$THIS_DIR"
 
 # Write all environment variables that start with "CONFIG_" to tup.config
 rm -rdf build

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Builds the firmware with the configuration specified by
+# environment variables named CONFIG_...
+# If DEPLOY is set, the deliverables are copied to Firmware/deploy/*
+# with the suffix $DEPLOY
+set -euo pipefail
+
+THIS_DIR="$(dirname "$0")"
+cd "$THIS_DIR/../Firmware"
+
+# Write all environment variables that start with "CONFIG_" to tup.config
+mkdir -p build
+rm build/*
+env | grep ^CONFIG > tup.config
+tup generate ./tup_build.sh
+bash -xe ./tup_build.sh
+
+# Deploy
+if ! [ -z ${DEPLOY+x} ]; then
+    mkdir -p deploy
+    cp build/ODriveFirmware.elf deploy/ODriveFirmware-"$DEPLOY".elf
+    cp build/ODriveFirmware.hex deploy/ODriveFirmware-"$DEPLOY".hex
+fi

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -9,8 +9,8 @@ THIS_DIR="$(dirname "$0")"
 cd "$THIS_DIR/../Firmware"
 
 # Write all environment variables that start with "CONFIG_" to tup.config
+rm -rdf build
 mkdir -p build
-rm build/*
 env | grep ^CONFIG > tup.config
 tup generate ./tup_build.sh
 bash -xe ./tup_build.sh


### PR DESCRIPTION
* Build firmware for all actively supported board versions
* Deploy *.elf and *.hex files for all boards automatically when a tag is pushed to master