### PR TITLE
Restrict USB comm to one endpoint or the other

### DIFF
--- a/Firmware/MotorControl/odrive_main.h
+++ b/Firmware/MotorControl/odrive_main.h
@@ -63,7 +63,7 @@ struct PWMMapping_t {
 struct BoardConfig_t {
     bool enable_uart = true;
     bool enable_i2c_instead_of_can = false;
-    bool enable_ascii_protocol_on_usb = true;
+    bool enable_ascii_protocol_on_usb = false;
 #if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 5 && HW_VERSION_VOLTAGE >= 48
     float brake_resistance = 2.0f;     // [ohm]
 #else

--- a/Firmware/communication/interface_usb.cpp
+++ b/Firmware/communication/interface_usb.cpp
@@ -106,7 +106,8 @@ static void usb_server_thread(void * ctx) {
 
 // Called from CDC_Receive_FS callback function, this allows the communication
 // thread to handle the incoming data
-// NOTE: 
+// NOTE: We're temporarily(?) restricting communication to one endpoint or the other
+// See issue #202 https://github.com/madcowswe/ODrive/issues/202
 void usb_process_packet(uint8_t *buf, uint32_t len, uint8_t endpoint_pair) {
     if (endpoint_pair == ODRIVE_OUT_EP && board_config.enable_ascii_protocol_on_usb == false) {
         usb_buf = buf;

--- a/Firmware/communication/interface_usb.cpp
+++ b/Firmware/communication/interface_usb.cpp
@@ -106,10 +106,20 @@ static void usb_server_thread(void * ctx) {
 
 // Called from CDC_Receive_FS callback function, this allows the communication
 // thread to handle the incoming data
+// NOTE: 
 void usb_process_packet(uint8_t *buf, uint32_t len, uint8_t endpoint_pair) {
-    usb_buf = buf;
-    usb_len = len;
-    active_endpoint_pair = endpoint_pair;
+    if (endpoint_pair == ODRIVE_OUT_EP && board_config.enable_ascii_protocol_on_usb == false) {
+        usb_buf = buf;
+        usb_len = len;
+        active_endpoint_pair = endpoint_pair;
+    }
+
+    if (endpoint_pair == CDC_OUT_EP && board_config.enable_ascii_protocol_on_usb == true) {
+        usb_buf = buf;
+        usb_len = len;
+        active_endpoint_pair = endpoint_pair;
+    }
+
     osSemaphoreRelease(sem_usb_rx);
 }
 


### PR DESCRIPTION
Quick workaround for #202.

Restricts communication to either CDC or Native USB endpoints.  Defaults `enable_ascii_protocol_on_usb` back to false (assumes most users want the binary/native protocol).