### PR TITLE
Expose crc as endpoint 1

### DIFF
--- a/Firmware/communication/communication.cpp
+++ b/Firmware/communication/communication.cpp
@@ -8,6 +8,8 @@
 #include "interface_can.hpp"
 #include "interface_i2c.h"
 
+#include "fibre/protocol.hpp"
+
 #include "odrive_main.h"
 #include "freertos_vars.h"
 #include "utils.h"
@@ -117,8 +119,11 @@ public:
 // how much headroom you have.
 static inline auto make_obj_tree() {
     return make_protocol_member_list(
-        make_protocol_ro_property("vbus_voltage", &vbus_voltage),
-        make_protocol_ro_property("serial_number", &serial_number),
+        // NOTE: First item is publicly accessible - as in the CRC signature is not required, same as endpoint 0
+        make_protocol_ro_property("json_crc", &json_crc_),
+        // NOTE: Ideally we don't change the order of these properties.  Any new properties
+        // should be appended rather than inserted.  The goal here is to establish a contract
+        // that the client can rely on to adapt its behavior based on versions
         make_protocol_ro_property("hw_version_major", &hw_version_major),
         make_protocol_ro_property("hw_version_minor", &hw_version_minor),
         make_protocol_ro_property("hw_version_variant", &hw_version_variant),
@@ -126,6 +131,9 @@ static inline auto make_obj_tree() {
         make_protocol_ro_property("fw_version_minor", &fw_version_minor),
         make_protocol_ro_property("fw_version_revision", &fw_version_revision),
         make_protocol_ro_property("fw_version_unreleased", &fw_version_unreleased),
+        // Going forward, it doesn't much matter what order things are in
+        make_protocol_ro_property("vbus_voltage", &vbus_voltage),
+        make_protocol_ro_property("serial_number", &serial_number),
         make_protocol_ro_property("user_config_loaded", const_cast<const bool *>(&user_config_loaded_)),
         make_protocol_ro_property("brake_resistor_armed", &brake_resistor_armed),
         make_protocol_object("system_stats",

--- a/Firmware/fibre/cpp/protocol.cpp
+++ b/Firmware/fibre/cpp/protocol.cpp
@@ -183,7 +183,8 @@ int BidirectionalPacketBasedChannel::process_packet(const uint8_t* buffer, size_
         // CRC over the entire JSON descriptor tree (this may change in future versions).
         uint16_t expected_trailer = endpoint_id ? json_crc_ : PROTOCOL_VERSION;
         uint16_t actual_trailer = buffer[length - 2] | (buffer[length - 1] << 8);
-        if (expected_trailer != actual_trailer) {
+        // Endpoint 1 is a special case in that it should expose the CRC publicly, no matter the trailer
+        if (expected_trailer != actual_trailer && endpoint_id != 1) {
             LOG_FIBRE("trailer mismatch for endpoint %d: expected %04x, got %04x\r\n", endpoint_id, expected_trailer, actual_trailer);
             return -1;
         }


### PR DESCRIPTION
This PR exposes the json_crc value as endpoint 1.  Endpoint 1 gets treated extra special in that it doesn't matter what the "trailer" or signature of the packet is.  e.g. for Endpoint 0 it expects the current protocol version, but to do so for endpoint 1 would require a change to fibre and would not be backwards compatible with prior firmware since it will be sending the crc instead of protocol version.

It also adds some notes to the area of code that sets up the endpoint members; instructing future developers to not re-arrange a group of members so that future revisions of the schema don't change endpoint numbers for members that are useful for determining board and firmware versions.