### PR TITLE
Fixed udev rules, udevadm trigger no longer required.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,7 +123,7 @@ Try step 5 again
 2. Install the ODrive tools by opening a terminal and typing `pip install odrive` <kbd>Enter</kbd>
 3. __Linux__: set up USB permissions
 ```bash
-    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="0d[0-9][0-9]", MODE="0666"' | sudo tee /etc/udev/rules.d/99-odrive.rules
+    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="0d[0-9][0-9]", MODE="0666"' | sudo tee /etc/udev/rules.d/91-odrive.rules
     sudo udevadm control --reload-rules
     sudo udevadm trigger # until you reboot you may need to do this everytime you reset the ODrive
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,7 +123,7 @@ Try step 5 again
 2. Install the ODrive tools by opening a terminal and typing `pip install odrive` <kbd>Enter</kbd>
 3. __Linux__: set up USB permissions
 ```bash
-    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="0d[0-9][0-9]", MODE="0666"' | sudo tee /etc/udev/rules.d/50-odrive.rules
+    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="0d[0-9][0-9]", MODE="0666"' | sudo tee /etc/udev/rules.d/99-odrive.rules
     sudo udevadm control --reload-rules
     sudo udevadm trigger # until you reboot you may need to do this everytime you reset the ODrive
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,7 +125,7 @@ Try step 5 again
 ```bash
     echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="0d[0-9][0-9]", MODE="0666"' | sudo tee /etc/udev/rules.d/91-odrive.rules
     sudo udevadm control --reload-rules
-    sudo udevadm trigger # until you reboot you may need to do this everytime you reset the ODrive
+    sudo udevadm trigger
 ```
 
 ## Start `odrivetool`

--- a/tools/odrive/utils.py
+++ b/tools/odrive/utils.py
@@ -151,7 +151,7 @@ def setup_udev_rules(logger):
         logger.error("This command only makes sense on Linux")
     if os.getuid() != 0:
         logger.warn("you should run this as root, otherwise it will probably not work")
-    with open('/etc/udev/rules.d/99-odrive.rules', 'w') as file:
+    with open('/etc/udev/rules.d/91-odrive.rules', 'w') as file:
         file.write('SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="0d3[0-9]", MODE="0666"\n')
     subprocess.check_call(["udevadm", "control", "--reload-rules"])
     subprocess.check_call(["udevadm", "trigger"])

--- a/tools/odrive/utils.py
+++ b/tools/odrive/utils.py
@@ -151,7 +151,7 @@ def setup_udev_rules(logger):
         logger.error("This command only makes sense on Linux")
     if os.getuid() != 0:
         logger.warn("you should run this as root, otherwise it will probably not work")
-    with open('/etc/udev/rules.d/50-odrive.rules', 'w') as file:
+    with open('/etc/udev/rules.d/99-odrive.rules', 'w') as file:
         file.write('SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="0d3[0-9]", MODE="0666"\n')
     subprocess.check_call(["udevadm", "control", "--reload-rules"])
     subprocess.check_call(["udevadm", "trigger"])


### PR DESCRIPTION
Because `/lib/udev/rules.d/50-udev-default.rules` lexically sorts after `50-odrive.rules`... our rule was getting overridden by the defaults. 🤦🏼‍♂️

Changed to `99-odrive.rules` to make sure it runs last.