### PR TITLE
Addition of CMake Build System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_VERSION 1)
 cmake_minimum_required(VERSION 3.7)
 
-# specify the cross compiler
+## Set for your ARM toolchain paths (or leave as is if you have them set in PATH variables)
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_C_COMPILER arm-none-eabi-gcc)
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
@@ -12,24 +12,25 @@ set(OBJCOPY arm-none-eabi-objcopy)
 set(OBJDUMP arm-none-eabi-objdump)
 set(SIZE arm-none-eabi-size)
 
-set(BOARD_DIR Firmware/Board/v3)
-set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/STM32F405RGTx_FLASH.ld)
+## Specific HAL settings =============
+set(TUP_CONFIG tup.config)
+execute_process(COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Read_TUP_Config.py" "${CMAKE_SOURCE_DIR}/Firmware/${TUP_CONFIG}" "${CMAKE_SOURCE_DIR}/Firmware/HAL_Config.lua" "${CMAKE_SOURCE_DIR}/CMake_Helpers")# OUTPUT_VARIABLE HAL_SETTINGS)
+
+include(${CMAKE_SOURCE_DIR}/CMake_Helpers/HAL_Generated.cmake)
+
+
 set(ARM_MATH_LIB ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Drivers/CMSIS/Lib/libarm_cortexM4lf_math.a)
 
-add_definitions("-DHW_VERSION_MAJOR=3" "-DHW_VERSION_MINOR=5")
-add_definitions("-DHW_VERSION_VOLTAGE=24")
-add_definitions("-DUSB_PROTOCOL_NATIVE")
-add_definitions("-DUART_PROTOCOL_NATIVE")
+
+## ====================================
 
 set(OPT_FLAGS "-Og -ffast-math -fno-finite-math-only")
 
-set(COMMON_FLAGS "-mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -Wfloat-conversion -mfloat-abi=hard -Wall -Wfloat-conversion -fdata-sections -ffunction-sections -g -gdwarf-2 ")
-
-
+set(COMMON_FLAGS "${COMMON_FLAGS} -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -Wall -Wfloat-conversion -fdata-sections -ffunction-sections -g -gdwarf-2 ")
 set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -std=c++14")
 set(CMAKE_C_FLAGS "${COMMON_FLAGS}  ${OPT_FLAGS} -std=c99")
 set(CMAKE_ASM_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -x assembler-with-cpp")
-set(CMAKE_EXE_LINKER_FLAGS  "-T${LINKER_SCRIPT} ${OPT_FLAGS} -specs=nosys.specs -specs=nano.specs -lnosys -lc -lm -Wl,--gc-sections -mthumb -mcpu=cortex-m4 -u _printf_float -u _scanf_float -Wl,--cref -Wl,--undefined=uxTopUsedPriority")
+set(CMAKE_EXE_LINKER_FLAGS  "${LINKER_FLAGS} -lc -lm -lnosys -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -u _printf_float -u _scanf_float -Wl,--cref -Wl,--gc-sections -Wl,--undefined=uxTopUsedPriority ${OPT_FLAGS}")
 link_libraries(${ARM_MATH_LIB})
 
 PROJECT(ODrive ASM CXX C)
@@ -37,7 +38,7 @@ PROJECT(ODrive ASM CXX C)
 add_definitions(-D__weak=__attribute__\(\(weak\)\))
 add_definitions(-D__packed=__attribute__\(\(__packed__\)\))
 add_definitions(-DUSE_HAL_DRIVER)
-add_definitions(-DSTM32F405xx)
+
 
 # Remove strings matching given regular expression from a list.
 # @param(in,out) aItems Reference of a list variable to filter.
@@ -55,55 +56,55 @@ function (filter_items aItems aRegEx)
     set(${aItems} ${${aItems}} PARENT_SCOPE)
 endfunction (filter_items)
 
-## Find the sources and correct HAL
+## Find the main sources
 FILE(GLOB_RECURSE SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/*.cpp" "${CMAKE_SOURCE_DIR}/Firmware/*.hpp" "${CMAKE_SOURCE_DIR}/Firmware/*.h" "${CMAKE_SOURCE_DIR}/Firmware/*.c")
 filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/Board/*")
 filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/fibre/*")
 
+## Remove posix based files.
 FILE(GLOB_RECURSE SOURCES_fibre "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.c*" "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.h*")
 filter_items(SOURCES_fibre "posix")
 LIST(APPEND SOURCES_NO_HAL ${SOURCES_fibre})
 
+# Find the specific HAL sources
 FILE(GLOB_RECURSE SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.cpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.hpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.c" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.h" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.s")
 filter_items(SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Src/prev_board_ver/*")
 set(SOURCES ${SOURCES_NO_HAL} ${SOURCES_HAL} )
-##======
 
-
+# From the sources, work out the folders that need to be include dirs.
 execute_process(COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Find_Include_Dirs.py" -SourcesAndHeaders "${SOURCES}" OUTPUT_VARIABLE INCLUDE_DIRS)
 include_directories(${INCLUDE_DIRS})
 include_directories(Firmware)
 
 
-## ======
+add_executable(${PROJECT_NAME}.elf ${SOURCES})
 
-
-
-add_executable(${PROJECT_NAME}.elf ${SOURCES} ${LINKER_SCRIPT})
-
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map")
+set(CMAKE_EXE_LINKER_FLAGS " ${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map")
 
 set(HEX_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.hex)
 set(BIN_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin)
+set(ASM_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.asm)
 
-
+# Runs BEFORE building starts (workaround for mingw) to create version.h (imitates TUP)
 add_custom_target(PreBuildHelper
         COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Create_Build_Folder.py" -Path "${CMAKE_SOURCE_DIR}/Firmware/build"
         COMMAND python "${CMAKE_SOURCE_DIR}/tools/odrive/version.py" --output ${CMAKE_SOURCE_DIR}/Firmware/build/version.h
         )
+add_dependencies(${PROJECT_NAME}.elf PreBuildHelper) # Workaround for mingw_arm
 
-
+# Runs AFTER building finishes to delete version.h (so TUP can generate its own if it likes)
 add_custom_command(TARGET ${PROJECT_NAME}.elf
         POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
-        COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
-        COMMENT "Building ${HEX_FILE}
-Building ${BIN_FILE}"
+        COMMAND ${OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
+        COMMAND ${OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
+        COMMAND ${OBJDUMP} $<TARGET_FILE:${PROJECT_NAME}.elf> -dSC> ${ASM_FILE}
+        COMMAND ${}
         COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Remove_Build_Folder.py" --Path "${CMAKE_SOURCE_DIR}/Firmware/build"
+        COMMAND ${SIZE} --format=SysV ${PROJECT_NAME}.elf
         )
 
-add_dependencies(${PROJECT_NAME}.elf PreBuildHelper)
 
+# Remote upload
 add_custom_target(UPLOAD
         arm-none-eabi-gdb -iex "target remote tcp:127.0.0.1:3333"
         -iex "monitor program $<TARGET_FILE:${PROJECT_NAME}.elf>"
@@ -114,7 +115,7 @@ add_custom_target(UPLOAD
 
 
 
-
+## Something up with .rodata .text .debugstr .debugline
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,6 @@ add_custom_command(TARGET ${PROJECT_NAME}.elf
         COMMAND ${OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
         COMMAND ${OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
         COMMAND ${OBJDUMP} $<TARGET_FILE:${PROJECT_NAME}.elf> -dSC> ${ASM_FILE}
-        COMMAND ${}
         COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Remove_Build_Folder.py" --Path "${CMAKE_SOURCE_DIR}/Firmware/build"
         COMMAND ${SIZE} --format=SysV ${PROJECT_NAME}.elf
         )
@@ -118,42 +117,3 @@ add_custom_target(UPLOAD
 ## Something up with .rodata .text .debugstr .debugline
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-## OLD ARCHIVED STUFF
-
-#include_directories(Firmware/Board/v3/Drivers/CMSIS)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx/Include)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Include)
-#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc)
-#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy)
-#include_directories(Firmware/Board/v3/Inc)
-#include_directories(Firmware/Board/v3/Inc/prev_board_ver)
-#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc)
-#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Core/Inc)
-#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS)
-#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/include)
-#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F)
-#include_directories(Firmware/build)
-#include_directories(Firmware/communication)
-#
-#include_directories(Firmware/Drivers/DRV8301)
-#include_directories(Firmware/fibre/cpp/include)
-#include_directories(Firmware/fibre/cpp/include/fibre)
-#include_directories(Firmware/MotorControl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,3 @@ add_custom_target(UPLOAD
 
 
 
-## Something up with .rodata .text .debugstr .debugline
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,158 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+cmake_minimum_required(VERSION 3.7)
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(AS arm-none-eabi-as)
+set(AR arm-none-eabi-ar)
+set(OBJCOPY arm-none-eabi-objcopy)
+set(OBJDUMP arm-none-eabi-objdump)
+set(SIZE arm-none-eabi-size)
+
+set(BOARD_DIR Firmware/Board/v3)
+set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/STM32F405RGTx_FLASH.ld)
+set(ARM_MATH_LIB ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Drivers/CMSIS/Lib/libarm_cortexM4lf_math.a)
+
+add_definitions("-DHW_VERSION_MAJOR=3" "-DHW_VERSION_MINOR=5")
+add_definitions("-DHW_VERSION_VOLTAGE=24")
+add_definitions("-DUSB_PROTOCOL_NATIVE")
+add_definitions("-DUART_PROTOCOL_NATIVE")
+
+set(OPT_FLAGS "-Og -ffast-math -fno-finite-math-only")
+
+set(COMMON_FLAGS "-mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -Wfloat-conversion -mfloat-abi=hard -Wall -Wfloat-conversion -fdata-sections -ffunction-sections -g -gdwarf-2 ")
+
+
+set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -std=c++14")
+set(CMAKE_C_FLAGS "${COMMON_FLAGS}  ${OPT_FLAGS} -std=c99")
+set(CMAKE_ASM_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -x assembler-with-cpp")
+set(CMAKE_EXE_LINKER_FLAGS  "-T${LINKER_SCRIPT} ${OPT_FLAGS} -specs=nosys.specs -specs=nano.specs -lnosys -lc -lm -Wl,--gc-sections -mthumb -mcpu=cortex-m4 -u _printf_float -u _scanf_float -Wl,--cref -Wl,--undefined=uxTopUsedPriority")
+link_libraries(${ARM_MATH_LIB})
+
+PROJECT(ODrive ASM CXX C)
+
+add_definitions(-D__weak=__attribute__\(\(weak\)\))
+add_definitions(-D__packed=__attribute__\(\(__packed__\)\))
+add_definitions(-DUSE_HAL_DRIVER)
+add_definitions(-DSTM32F405xx)
+
+# Remove strings matching given regular expression from a list.
+# @param(in,out) aItems Reference of a list variable to filter.
+# @param aRegEx Value of regular expression to match.
+function (filter_items aItems aRegEx)
+    # For each item in our list
+    foreach (item ${${aItems}})
+        # Check if our items matches our regular expression
+        if ("${item}" MATCHES ${aRegEx})
+            # Remove current item from our list
+            list (REMOVE_ITEM ${aItems} ${item})
+        endif ("${item}" MATCHES ${aRegEx})
+    endforeach(item)
+    # Provide output parameter
+    set(${aItems} ${${aItems}} PARENT_SCOPE)
+endfunction (filter_items)
+
+## Find the sources and correct HAL
+FILE(GLOB_RECURSE SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/*.cpp" "${CMAKE_SOURCE_DIR}/Firmware/*.hpp" "${CMAKE_SOURCE_DIR}/Firmware/*.h" "${CMAKE_SOURCE_DIR}/Firmware/*.c")
+filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/Board/*")
+filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/fibre/*")
+
+FILE(GLOB_RECURSE SOURCES_fibre "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.c*" "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.h*")
+filter_items(SOURCES_fibre "posix")
+LIST(APPEND SOURCES_NO_HAL ${SOURCES_fibre})
+
+FILE(GLOB_RECURSE SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.cpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.hpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.c" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.h" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.s")
+filter_items(SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Src/prev_board_ver/*")
+set(SOURCES ${SOURCES_NO_HAL} ${SOURCES_HAL} )
+##======
+
+
+execute_process(COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Find_Include_Dirs.py" -SourcesAndHeaders "${SOURCES}" OUTPUT_VARIABLE INCLUDE_DIRS)
+include_directories(${INCLUDE_DIRS})
+include_directories(Firmware)
+
+
+## ======
+
+
+
+add_executable(${PROJECT_NAME}.elf ${SOURCES} ${LINKER_SCRIPT})
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map")
+
+set(HEX_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.hex)
+set(BIN_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin)
+
+
+add_custom_target(PreBuildHelper
+        COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Create_Build_Folder.py" -Path "${CMAKE_SOURCE_DIR}/Firmware/build"
+        COMMAND python "${CMAKE_SOURCE_DIR}/tools/odrive/version.py" --output ${CMAKE_SOURCE_DIR}/Firmware/build/version.h
+        )
+
+
+add_custom_command(TARGET ${PROJECT_NAME}.elf
+        POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
+        COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
+        COMMENT "Building ${HEX_FILE}
+Building ${BIN_FILE}"
+        COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Remove_Build_Folder.py" --Path "${CMAKE_SOURCE_DIR}/Firmware/build"
+        )
+
+add_dependencies(${PROJECT_NAME}.elf PreBuildHelper)
+
+add_custom_target(UPLOAD
+        arm-none-eabi-gdb -iex "target remote tcp:127.0.0.1:3333"
+        -iex "monitor program $<TARGET_FILE:${PROJECT_NAME}.elf>"
+        -iex "monitor reset init"
+        -iex "disconnect" -iex "quit")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## OLD ARCHIVED STUFF
+
+#include_directories(Firmware/Board/v3/Drivers/CMSIS)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx/Include)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Include)
+#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc)
+#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy)
+#include_directories(Firmware/Board/v3/Inc)
+#include_directories(Firmware/Board/v3/Inc/prev_board_ver)
+#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc)
+#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Core/Inc)
+#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS)
+#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/include)
+#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F)
+#include_directories(Firmware/build)
+#include_directories(Firmware/communication)
+#
+#include_directories(Firmware/Drivers/DRV8301)
+#include_directories(Firmware/fibre/cpp/include)
+#include_directories(Firmware/fibre/cpp/include/fibre)
+#include_directories(Firmware/MotorControl)

--- a/CMakeLists_template.txt
+++ b/CMakeLists_template.txt
@@ -79,10 +79,11 @@ include_directories(Firmware)
 
 add_executable(${PROJECT_NAME}.elf ${SOURCES})
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map")
+set(CMAKE_EXE_LINKER_FLAGS " ${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map")
 
 set(HEX_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.hex)
 set(BIN_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin)
+set(ASM_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.asm)
 
 # Runs BEFORE building starts (workaround for mingw) to create version.h (imitates TUP)
 add_custom_target(PreBuildHelper
@@ -91,12 +92,12 @@ add_custom_target(PreBuildHelper
         )
 add_dependencies(${PROJECT_NAME}.elf PreBuildHelper) # Workaround for mingw_arm
 
-# Runs AFTER building finishes to delete version.h (imitates TUP)
+# Runs AFTER building finishes to delete version.h (so TUP can generate its own if it likes)
 add_custom_command(TARGET ${PROJECT_NAME}.elf
         POST_BUILD
         COMMAND ${OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
         COMMAND ${OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
-        COMMAND ${}
+        COMMAND ${OBJDUMP} $<TARGET_FILE:${PROJECT_NAME}.elf> -dSC> ${ASM_FILE}
         COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Remove_Build_Folder.py" --Path "${CMAKE_SOURCE_DIR}/Firmware/build"
         COMMAND ${SIZE} --format=SysV ${PROJECT_NAME}.elf
         )
@@ -113,45 +114,3 @@ add_custom_target(UPLOAD
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-## OLD ARCHIVED STUFF
-
-#include_directories(Firmware/Board/v3/Drivers/CMSIS)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx/Include)
-#include_directories(Firmware/Board/v3/Drivers/CMSIS/Include)
-#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc)
-#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy)
-#include_directories(Firmware/Board/v3/Inc)
-#include_directories(Firmware/Board/v3/Inc/prev_board_ver)
-#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc)
-#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Core/Inc)
-#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS)
-#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/include)
-#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F)
-#include_directories(Firmware/build)
-#include_directories(Firmware/communication)
-#
-#include_directories(Firmware/Drivers/DRV8301)
-#include_directories(Firmware/fibre/cpp/include)
-#include_directories(Firmware/fibre/cpp/include/fibre)
-#include_directories(Firmware/MotorControl)

--- a/CMakeLists_template.txt
+++ b/CMakeLists_template.txt
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_VERSION 1)
 cmake_minimum_required(VERSION 3.7)
 
-# specify the cross compiler
+## Set for your ARM toolchain paths (or leave as is if you have them set in PATH variables)
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_C_COMPILER arm-none-eabi-gcc)
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
@@ -12,24 +12,25 @@ set(OBJCOPY arm-none-eabi-objcopy)
 set(OBJDUMP arm-none-eabi-objdump)
 set(SIZE arm-none-eabi-size)
 
-set(BOARD_DIR Firmware/Board/v3)
-set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/STM32F405RGTx_FLASH.ld)
+## Specific HAL settings =============
+set(TUP_CONFIG tup.config)
+execute_process(COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Read_TUP_Config.py" "${CMAKE_SOURCE_DIR}/Firmware/${TUP_CONFIG}" "${CMAKE_SOURCE_DIR}/Firmware/HAL_Config.lua" "${CMAKE_SOURCE_DIR}/CMake_Helpers")# OUTPUT_VARIABLE HAL_SETTINGS)
+
+include(${CMAKE_SOURCE_DIR}/CMake_Helpers/HAL_Generated.cmake)
+
+
 set(ARM_MATH_LIB ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Drivers/CMSIS/Lib/libarm_cortexM4lf_math.a)
 
-add_definitions("-DHW_VERSION_MAJOR=3" "-DHW_VERSION_MINOR=5")
-add_definitions("-DHW_VERSION_VOLTAGE=24")
-add_definitions("-DUSB_PROTOCOL_NATIVE")
-add_definitions("-DUART_PROTOCOL_NATIVE")
+
+## ====================================
 
 set(OPT_FLAGS "-Og -ffast-math -fno-finite-math-only")
 
-set(COMMON_FLAGS "-mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -Wfloat-conversion -mfloat-abi=hard -Wall -Wfloat-conversion -fdata-sections -ffunction-sections -g -gdwarf-2 ")
-
-
+set(COMMON_FLAGS "${COMMON_FLAGS} -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -Wall -Wfloat-conversion -fdata-sections -ffunction-sections -g -gdwarf-2 ")
 set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -std=c++14")
 set(CMAKE_C_FLAGS "${COMMON_FLAGS}  ${OPT_FLAGS} -std=c99")
 set(CMAKE_ASM_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -x assembler-with-cpp")
-set(CMAKE_EXE_LINKER_FLAGS  "-T${LINKER_SCRIPT} ${OPT_FLAGS} -specs=nosys.specs -specs=nano.specs -lnosys -lc -lm -Wl,--gc-sections -mthumb -mcpu=cortex-m4 -u _printf_float -u _scanf_float -Wl,--cref -Wl,--undefined=uxTopUsedPriority")
+set(CMAKE_EXE_LINKER_FLAGS  "${LINKER_FLAGS} -lc -lm -lnosys -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -u _printf_float -u _scanf_float -Wl,--cref -Wl,--gc-sections -Wl,--undefined=uxTopUsedPriority ${OPT_FLAGS}")
 link_libraries(${ARM_MATH_LIB})
 
 PROJECT(ODrive ASM CXX C)
@@ -37,7 +38,7 @@ PROJECT(ODrive ASM CXX C)
 add_definitions(-D__weak=__attribute__\(\(weak\)\))
 add_definitions(-D__packed=__attribute__\(\(__packed__\)\))
 add_definitions(-DUSE_HAL_DRIVER)
-add_definitions(-DSTM32F405xx)
+
 
 # Remove strings matching given regular expression from a list.
 # @param(in,out) aItems Reference of a list variable to filter.
@@ -55,56 +56,53 @@ function (filter_items aItems aRegEx)
     set(${aItems} ${${aItems}} PARENT_SCOPE)
 endfunction (filter_items)
 
-## Find the sources and correct HAL
+## Find the main sources
 FILE(GLOB_RECURSE SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/*.cpp" "${CMAKE_SOURCE_DIR}/Firmware/*.hpp" "${CMAKE_SOURCE_DIR}/Firmware/*.h" "${CMAKE_SOURCE_DIR}/Firmware/*.c")
 filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/Board/*")
 filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/fibre/*")
 
+## Remove posix based files.
 FILE(GLOB_RECURSE SOURCES_fibre "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.c*" "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.h*")
 filter_items(SOURCES_fibre "posix")
 LIST(APPEND SOURCES_NO_HAL ${SOURCES_fibre})
 
+# Find the specific HAL sources
 FILE(GLOB_RECURSE SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.cpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.hpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.c" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.h" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.s")
 filter_items(SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Src/prev_board_ver/*")
 set(SOURCES ${SOURCES_NO_HAL} ${SOURCES_HAL} )
-##======
 
-## Temp To build, will reconfigure
-
+# From the sources, work out the folders that need to be include dirs.
 execute_process(COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Find_Include_Dirs.py" -SourcesAndHeaders "${SOURCES}" OUTPUT_VARIABLE INCLUDE_DIRS)
 include_directories(${INCLUDE_DIRS})
 include_directories(Firmware)
 
 
-## ======
-
-
-
-add_executable(${PROJECT_NAME}.elf ${SOURCES} ${LINKER_SCRIPT})
+add_executable(${PROJECT_NAME}.elf ${SOURCES})
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map")
 
 set(HEX_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.hex)
 set(BIN_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin)
 
-
+# Runs BEFORE building starts (workaround for mingw) to create version.h (imitates TUP)
 add_custom_target(PreBuildHelper
         COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Create_Build_Folder.py" -Path "${CMAKE_SOURCE_DIR}/Firmware/build"
         COMMAND python "${CMAKE_SOURCE_DIR}/tools/odrive/version.py" --output ${CMAKE_SOURCE_DIR}/Firmware/build/version.h
         )
+add_dependencies(${PROJECT_NAME}.elf PreBuildHelper) # Workaround for mingw_arm
 
-
+# Runs AFTER building finishes to delete version.h (imitates TUP)
 add_custom_command(TARGET ${PROJECT_NAME}.elf
         POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
-        COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
-        COMMENT "Building ${HEX_FILE}
-Building ${BIN_FILE}"
+        COMMAND ${OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
+        COMMAND ${OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
+        COMMAND ${}
         COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Remove_Build_Folder.py" --Path "${CMAKE_SOURCE_DIR}/Firmware/build"
+        COMMAND ${SIZE} --format=SysV ${PROJECT_NAME}.elf
         )
 
-add_dependencies(${PROJECT_NAME}.elf PreBuildHelper)
 
+# Remote upload
 add_custom_target(UPLOAD
         arm-none-eabi-gdb -iex "target remote tcp:127.0.0.1:3333"
         -iex "monitor program $<TARGET_FILE:${PROJECT_NAME}.elf>"

--- a/CMakeLists_template.txt
+++ b/CMakeLists_template.txt
@@ -1,0 +1,159 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+cmake_minimum_required(VERSION 3.7)
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(AS arm-none-eabi-as)
+set(AR arm-none-eabi-ar)
+set(OBJCOPY arm-none-eabi-objcopy)
+set(OBJDUMP arm-none-eabi-objdump)
+set(SIZE arm-none-eabi-size)
+
+set(BOARD_DIR Firmware/Board/v3)
+set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/STM32F405RGTx_FLASH.ld)
+set(ARM_MATH_LIB ${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Drivers/CMSIS/Lib/libarm_cortexM4lf_math.a)
+
+add_definitions("-DHW_VERSION_MAJOR=3" "-DHW_VERSION_MINOR=5")
+add_definitions("-DHW_VERSION_VOLTAGE=24")
+add_definitions("-DUSB_PROTOCOL_NATIVE")
+add_definitions("-DUART_PROTOCOL_NATIVE")
+
+set(OPT_FLAGS "-Og -ffast-math -fno-finite-math-only")
+
+set(COMMON_FLAGS "-mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -Wfloat-conversion -mfloat-abi=hard -Wall -Wfloat-conversion -fdata-sections -ffunction-sections -g -gdwarf-2 ")
+
+
+set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -std=c++14")
+set(CMAKE_C_FLAGS "${COMMON_FLAGS}  ${OPT_FLAGS} -std=c99")
+set(CMAKE_ASM_FLAGS "${COMMON_FLAGS} ${OPT_FLAGS} -x assembler-with-cpp")
+set(CMAKE_EXE_LINKER_FLAGS  "-T${LINKER_SCRIPT} ${OPT_FLAGS} -specs=nosys.specs -specs=nano.specs -lnosys -lc -lm -Wl,--gc-sections -mthumb -mcpu=cortex-m4 -u _printf_float -u _scanf_float -Wl,--cref -Wl,--undefined=uxTopUsedPriority")
+link_libraries(${ARM_MATH_LIB})
+
+PROJECT(ODrive ASM CXX C)
+
+add_definitions(-D__weak=__attribute__\(\(weak\)\))
+add_definitions(-D__packed=__attribute__\(\(__packed__\)\))
+add_definitions(-DUSE_HAL_DRIVER)
+add_definitions(-DSTM32F405xx)
+
+# Remove strings matching given regular expression from a list.
+# @param(in,out) aItems Reference of a list variable to filter.
+# @param aRegEx Value of regular expression to match.
+function (filter_items aItems aRegEx)
+    # For each item in our list
+    foreach (item ${${aItems}})
+        # Check if our items matches our regular expression
+        if ("${item}" MATCHES ${aRegEx})
+            # Remove current item from our list
+            list (REMOVE_ITEM ${aItems} ${item})
+        endif ("${item}" MATCHES ${aRegEx})
+    endforeach(item)
+    # Provide output parameter
+    set(${aItems} ${${aItems}} PARENT_SCOPE)
+endfunction (filter_items)
+
+## Find the sources and correct HAL
+FILE(GLOB_RECURSE SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/*.cpp" "${CMAKE_SOURCE_DIR}/Firmware/*.hpp" "${CMAKE_SOURCE_DIR}/Firmware/*.h" "${CMAKE_SOURCE_DIR}/Firmware/*.c")
+filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/Board/*")
+filter_items(SOURCES_NO_HAL "${CMAKE_SOURCE_DIR}/Firmware/fibre/*")
+
+FILE(GLOB_RECURSE SOURCES_fibre "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.c*" "${CMAKE_SOURCE_DIR}/Firmware/fibre/cpp/*.h*")
+filter_items(SOURCES_fibre "posix")
+LIST(APPEND SOURCES_NO_HAL ${SOURCES_fibre})
+
+FILE(GLOB_RECURSE SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.cpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.hpp" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.c" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.h" "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/*.s")
+filter_items(SOURCES_HAL "${CMAKE_SOURCE_DIR}/${BOARD_DIR}/Src/prev_board_ver/*")
+set(SOURCES ${SOURCES_NO_HAL} ${SOURCES_HAL} )
+##======
+
+## Temp To build, will reconfigure
+
+execute_process(COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Find_Include_Dirs.py" -SourcesAndHeaders "${SOURCES}" OUTPUT_VARIABLE INCLUDE_DIRS)
+include_directories(${INCLUDE_DIRS})
+include_directories(Firmware)
+
+
+## ======
+
+
+
+add_executable(${PROJECT_NAME}.elf ${SOURCES} ${LINKER_SCRIPT})
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map")
+
+set(HEX_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.hex)
+set(BIN_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin)
+
+
+add_custom_target(PreBuildHelper
+        COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Create_Build_Folder.py" -Path "${CMAKE_SOURCE_DIR}/Firmware/build"
+        COMMAND python "${CMAKE_SOURCE_DIR}/tools/odrive/version.py" --output ${CMAKE_SOURCE_DIR}/Firmware/build/version.h
+        )
+
+
+add_custom_command(TARGET ${PROJECT_NAME}.elf
+        POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
+        COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
+        COMMENT "Building ${HEX_FILE}
+Building ${BIN_FILE}"
+        COMMAND python "${CMAKE_SOURCE_DIR}/CMake_Helpers/CMake_Remove_Build_Folder.py" --Path "${CMAKE_SOURCE_DIR}/Firmware/build"
+        )
+
+add_dependencies(${PROJECT_NAME}.elf PreBuildHelper)
+
+add_custom_target(UPLOAD
+        arm-none-eabi-gdb -iex "target remote tcp:127.0.0.1:3333"
+        -iex "monitor program $<TARGET_FILE:${PROJECT_NAME}.elf>"
+        -iex "monitor reset init"
+        -iex "disconnect" -iex "quit")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## OLD ARCHIVED STUFF
+
+#include_directories(Firmware/Board/v3/Drivers/CMSIS)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Device/ST/STM32F4xx/Include)
+#include_directories(Firmware/Board/v3/Drivers/CMSIS/Include)
+#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc)
+#include_directories(Firmware/Board/v3/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy)
+#include_directories(Firmware/Board/v3/Inc)
+#include_directories(Firmware/Board/v3/Inc/prev_board_ver)
+#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc)
+#include_directories(Firmware/Board/v3/Middlewares/ST/STM32_USB_Device_Library/Core/Inc)
+#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS)
+#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/include)
+#include_directories(Firmware/Board/v3/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F)
+#include_directories(Firmware/build)
+#include_directories(Firmware/communication)
+#
+#include_directories(Firmware/Drivers/DRV8301)
+#include_directories(Firmware/fibre/cpp/include)
+#include_directories(Firmware/fibre/cpp/include/fibre)
+#include_directories(Firmware/MotorControl)

--- a/CMake_Helpers/CMake_Create_Build_Folder.py
+++ b/CMake_Helpers/CMake_Create_Build_Folder.py
@@ -1,0 +1,6 @@
+import os,sys,time
+Path = sys.argv[2]
+if not os.path.isdir(Path):
+    print("Created build/version.h")
+    os.mkdir(Path)
+    time.sleep(0.1)

--- a/CMake_Helpers/CMake_Find_Include_Dirs.py
+++ b/CMake_Helpers/CMake_Find_Include_Dirs.py
@@ -1,0 +1,29 @@
+import sys
+SourcesHeaders = sys.argv[2].split(";")
+
+def ShouldBeIncluded(Path):
+    Path = Path.lower()
+    return ".h" in Path or "include" in Path
+
+def RemoveToLast(In,Char):
+    for i in range(len(In)-1,-1,-1):
+        if In[i] == Char:
+            return In[:i]
+
+Headers = []
+for FilePath in SourcesHeaders:
+    if ShouldBeIncluded(FilePath):
+        Headers.append(FilePath)
+
+
+
+Folders = []
+for HeaderFilePath in Headers:
+    while ShouldBeIncluded(HeaderFilePath):
+        HeaderFilePath = RemoveToLast(HeaderFilePath,'/')
+        Folders.append(HeaderFilePath)
+
+
+Folders = sorted(list(set(Folders)))
+for i in Folders:
+    print(i,end=";")

--- a/CMake_Helpers/CMake_Read_TUP_Config.py
+++ b/CMake_Helpers/CMake_Read_TUP_Config.py
@@ -1,0 +1,122 @@
+import sys
+
+Debug = False
+
+if Debug:
+    TupConfigPath = "D:/LaptopSync/CLionWorkspace/ODrive/Firmware/tup.config"
+    HALConfigLuaPath = "D:/LaptopSync/CLionWorkspace/ODrive/Firmware/HAL_Config.lua"
+else:
+    TupConfigPath = sys.argv[1]
+    HALConfigLuaPath = sys.argv[2]
+    HelperPath = sys.argv[3]
+
+
+def ParseConfig(Path):
+    with open(Path,"r") as File:
+        FileLines = File.readlines()
+
+    for C,Line in enumerate(FileLines): ## Remove comments
+        if "#" in Line:
+            FileLines[C] = Line[:Line.index("#")]+"\n"
+
+    Settings = {}
+    for C,Line in enumerate(FileLines):
+        if "=" in Line:
+            ThisSetting = Line.rstrip().split("=")
+            if ThisSetting[0] in Settings:
+                print("Warning:",ThisSetting[0], "Redefined. Line:",C+1)
+
+            Settings[ThisSetting[0].replace("CONFIG_","")] = ThisSetting[1]
+
+    return Settings
+
+
+
+
+def ParseLua(Path):
+    with open(Path,"r") as File:
+        FileLines = File.readlines()
+
+    for C,OrigLine in enumerate(FileLines):
+        if "--" in FileLines[C]:
+            FileLines[C] = FileLines[C][:FileLines[C].index("--")]+"\n" ## Remove comments
+
+
+        FileLines[C] = FileLines[C].replace(" then",":")
+        FileLines[C] = FileLines[C].replace("elseif ","elif ")
+        FileLines[C] = FileLines[C].replace("..","+")
+        FileLines[C] = FileLines[C].replace("tup.","lua_interpreter.")
+        FileLines[C] = FileLines[C].replace("'",'"')
+        FileLines[C] = FileLines[C].replace('LDFLAGS',"lua_interpreter.ldf")
+        FileLines[C] = FileLines[C].replace('FLAGS',"lua_interpreter.f")
+        FileLines[C] = FileLines[C].replace('else',"else:")
+        FileLines[C] = FileLines[C].replace('end',"")
+    CodeStr = ""
+    for i in FileLines:
+        CodeStr += i
+    return CodeStr
+
+
+
+class LuaReturn:
+    def __init__(self):
+        self.f = []
+        self.ldf = []
+
+    def getconfig(self,In):
+        if In in ConfigSettings:
+            return ConfigSettings[In]
+        else:
+            return False
+
+
+def Agglomerate(In,SplitChar):
+    L = []
+    S = ""
+    for Char in In:
+        if Char == SplitChar:
+            if S != "":
+                L.append(S)
+                S = ""
+        S += Char
+    if S != "":
+        L.append(S)
+    return L
+
+def error(In):
+    print("ERROR IN CONFIG/HAL",In)
+    exit(1)
+
+# Parse Config for vars
+# Parse luascript and convert to python
+# Run pyluascript with config
+
+ConfigSettings = ParseConfig(TupConfigPath)
+PyLuaScript = ParseLua(HALConfigLuaPath)
+
+
+lua_interpreter = LuaReturn();
+exec(PyLuaScript)
+
+Flags = Agglomerate(lua_interpreter.f,"-")
+LDFlags = Agglomerate(lua_interpreter.ldf,"-")
+import os
+if os.path.exists(HelperPath+"/HAL_Generated.cmake"):
+    os.remove(HelperPath+"/HAL_Generated.cmake")
+
+with open(HelperPath+"/HAL_Generated.cmake","w") as F:
+    F.write("set(BOARD_DIR Firmware/" +boarddir+")\n")
+
+    F.write('set(COMMON_FLAGS "${COMMON_FLAGS} ')
+    for i in Flags:
+        F.write(i+" ")
+    F.write('")')
+    F.write("\n")
+
+    F.write('set(LINKER_FLAGS "')
+    for i in LDFlags:
+        if "-T" in i:
+            i = "-T${CMAKE_SOURCE_DIR}/Firmware/"+i[2:]
+        F.write(i+" ")
+    F.write('")')
+    F.write("\n")

--- a/CMake_Helpers/CMake_Remove_Build_Folder.py
+++ b/CMake_Helpers/CMake_Remove_Build_Folder.py
@@ -1,0 +1,6 @@
+import sys,os,time,shutil
+Path = sys.argv[2]
+if os.path.isdir(Path):
+    shutil.rmtree(Path)
+    time.sleep(0.1)
+    print("Removed build/version.h")

--- a/Firmware/HAL_Config.lua
+++ b/Firmware/HAL_Config.lua
@@ -1,0 +1,93 @@
+-- Switch between board versions using TUP.config even if using CLion build system
+boardversion = tup.getconfig("BOARD_VERSION")
+if boardversion == "v3.1" then
+    boarddir = 'Board/v3' -- currently all platform code is in the same v3.3 directory
+    FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=1"
+    FLAGS += '-DSTM32F405xx'
+    LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
+
+elseif boardversion == "v3.2" then
+    boarddir = 'Board/v3'
+    FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=2"
+    FLAGS += '-DSTM32F405xx'
+    LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
+
+elseif boardversion == "v3.3" then
+    boarddir = 'Board/v3'
+    FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=3"
+    FLAGS += '-DSTM32F405xx'
+    LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
+elseif boardversion == "v3.4-24V" then
+    boarddir = 'Board/v3'
+    FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=4"
+    FLAGS += "-DHW_VERSION_VOLTAGE=24"
+    FLAGS += '-DSTM32F405xx'
+    LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
+
+elseif boardversion == "v3.4-48V" then
+    boarddir = 'Board/v3'
+    FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=4"
+    FLAGS += "-DHW_VERSION_VOLTAGE=48"
+    FLAGS += '-DSTM32F405xx'
+    LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
+
+elseif boardversion == "v3.5-24V" then
+    boarddir = 'Board/v3'
+    FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=5"
+    FLAGS += "-DHW_VERSION_VOLTAGE=24"
+    FLAGS += '-DSTM32F405xx'
+    LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
+
+elseif boardversion == "v3.5-48V" then
+    boarddir = 'Board/v3'
+    FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=5"
+    FLAGS += "-DHW_VERSION_VOLTAGE=48"
+    FLAGS += '-DSTM32F405xx'
+    LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
+elseif boardversion == "" then
+    error("board version not specified - take a look at tup.config.default")
+else
+    error("unknown board version "..boardversion)
+end
+buildsuffix = boardversion
+
+-- USB I/O settings
+if tup.getconfig("USB_PROTOCOL") == "native" or tup.getconfig("USB_PROTOCOL") == "" then
+    FLAGS += "-DUSB_PROTOCOL_NATIVE"
+elseif tup.getconfig("USB_PROTOCOL") == "native-stream" then
+    FLAGS += "-DUSB_PROTOCOL_NATIVE_STREAM_BASED"
+elseif tup.getconfig("USB_PROTOCOL") == "stdout" then
+    FLAGS += "-DUSB_PROTOCOL_STDOUT"
+elseif tup.getconfig("USB_PROTOCOL") == "none" then
+    FLAGS += "-DUSB_PROTOCOL_NONE"
+else
+    error("unknown USB protocol")
+end
+
+-- UART I/O settings
+if tup.getconfig("UART_PROTOCOL") == "native" then
+    FLAGS += "-DUART_PROTOCOL_NATIVE"
+elseif tup.getconfig("UART_PROTOCOL") == "ascii" or tup.getconfig("UART_PROTOCOL") == "" then
+    FLAGS += "-DUART_PROTOCOL_ASCII"
+elseif tup.getconfig("UART_PROTOCOL") == "stdout" then
+    FLAGS += "-DUART_PROTOCOL_STDOUT"
+elseif tup.getconfig("UART_PROTOCOL") == "none" then
+    FLAGS += "-DUART_PROTOCOL_NONE"
+else
+    error("unknown UART protocol "..tup.getconfig("UART_PROTOCOL"))
+end
+
+-- GPIO settings
+if tup.getconfig("STEP_DIR") == "y" then
+    if tup.getconfig("UART_PROTOCOL") == "none" then
+        FLAGS += "-DUSE_GPIO_MODE_STEP_DIR"
+    else
+        error("Step/dir mode conflicts with UART. Set CONFIG_UART_PROTOCOL to none.")
+    end
+end
+
+-- Compiler settings
+if tup.getconfig("STRICT") == "true" then
+    FLAGS += '-Werror'
+end
+

--- a/Firmware/HAL_Config.lua
+++ b/Firmware/HAL_Config.lua
@@ -4,18 +4,21 @@ if boardversion == "v3.1" then
     boarddir = 'Board/v3' -- currently all platform code is in the same v3.3 directory
     FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=1"
     FLAGS += '-DSTM32F405xx'
+    FLAGS += "-DHW_VERSION_VOLTAGE=24"
     LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
 
 elseif boardversion == "v3.2" then
     boarddir = 'Board/v3'
     FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=2"
     FLAGS += '-DSTM32F405xx'
+    FLAGS += "-DHW_VERSION_VOLTAGE=24"
     LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
 
 elseif boardversion == "v3.3" then
     boarddir = 'Board/v3'
     FLAGS += "-DHW_VERSION_MAJOR=3 -DHW_VERSION_MINOR=3"
     FLAGS += '-DSTM32F405xx'
+    FLAGS += "-DHW_VERSION_VOLTAGE=24"
     LDFLAGS += '-T'..boarddir..'/STM32F405RGTx_FLASH.ld'
 elseif boardversion == "v3.4-24V" then
     boarddir = 'Board/v3'

--- a/Firmware/build.lua
+++ b/Firmware/build.lua
@@ -98,7 +98,8 @@ function GCCToolchain(prefix, builddir, compiler_flags, linker_flags)
                 outputs={output_name..'.elf', extra_outputs={output_name..'.map'}}
             }
             -- display the size
-            tup.frule{inputs={output_name..'.elf'}, command=prefix..'size %f'}
+            tup.frule{inputs={output_name..'.elf'}, command=prefix..'size --format=SysV %f'}
+            tup.frule{inputs={output_name..'.elf'}, command=prefix..'objdump %f -dSC > %o',outputs={output_name..'.asm'}}
             -- create *.hex and *.bin output formats
             tup.frule{inputs={output_name..'.elf'}, command=prefix..'objcopy -O ihex %f %o', outputs={output_name..'.hex'}}
             tup.frule{inputs={output_name..'.elf'}, command=prefix..'objcopy -O binary -S %f %o', outputs={output_name..'.bin'}}


### PR DESCRIPTION
CMake and CLion are excellent tools with debuggers that are very straightforward to use but extremely powerful. This PR adds the support of CMake and Clion to the build system portfolio, as well as beginning to split the system into a unified HAL instead of compiling only for F4.

This addition does not break the current VScode builder, VScode doesn't even know its there. The CMake builder has been designed so as to work around the VScode system, leaving no trace in any parts that VScode relies on. 

Configuration to the CMake builder is still done using the standard tup.config files used by VScode, basically if you can compile using VScode then you'll be able to compile with this too.  

Thanks for the great work on this project, and good things its bringing to the community! 

 - Sam :)