### PR TITLE
Fix rounding issue in arm_cos_f32

### DIFF
--- a/Firmware/MotorControl/arm_cos_f32.c
+++ b/Firmware/MotorControl/arm_cos_f32.c
@@ -1,0 +1,116 @@
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS DSP Library
+ * Title:        arm_cos_f32.c
+ * Description:  Fast cosine calculation for floating-point values
+ *
+ * $Date:        27. January 2017
+ * $Revision:    V.1.5.1
+ *
+ * Target Processor: Cortex-M cores
+ * -------------------------------------------------------------------- */
+/*
+ * Copyright (C) 2010-2017 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stm32f4xx_hal.h>  // Sets up the correct chip specifc defines required by arm_math
+#define ARM_MATH_CM4 // TODO: might change in future board versions
+#include "arm_math.h"
+#include "arm_common_tables.h"
+/**
+ * @ingroup groupFastMath
+ */
+
+/**
+ * @defgroup cos Cosine
+ *
+ * Computes the trigonometric cosine function using a combination of table lookup
+ * and linear interpolation.  There are separate functions for
+ * Q15, Q31, and floating-point data types.
+ * The input to the floating-point version is in radians and in the range [0 2*pi) while the
+ * fixed-point Q15 and Q31 have a scaled input with the range
+ * [0 +0.9999] mapping to [0 2*pi).  The fixed-point range is chosen so that a
+ * value of 2*pi wraps around to 0.
+ *
+ * The implementation is based on table lookup using 256 values together with linear interpolation.
+ * The steps used are:
+ *  -# Calculation of the nearest integer table index
+ *  -# Compute the fractional portion (fract) of the table index.
+ *  -# The final result equals <code>(1.0f-fract)*a + fract*b;</code>
+ *
+ * where
+ * <pre>
+ *    b=Table[index+0];
+ *    c=Table[index+1];
+ * </pre>
+ */
+
+ /**
+ * @addtogroup cos
+ * @{
+ */
+
+/**
+ * @brief  Fast approximation to the trigonometric cosine function for floating-point data.
+ * @param[in] x input value in radians.
+ * @return cos(x).
+ */
+
+float32_t our_arm_cos_f32(
+  float32_t x)
+{
+  float32_t cosVal, fract, in;                   /* Temporary variables for input, output */
+  uint16_t index;                                /* Index variable */
+  float32_t a, b;                                /* Two nearest output values */
+  int32_t n;
+  float32_t findex;
+
+  /* input x is in radians */
+  /* Scale the input to [0 1] range from [0 2*PI] , divide input by 2*pi, add 0.25 (pi/2) to read sine table */
+  in = x * 0.159154943092f + 0.25f;
+
+  /* Calculation of floor value of input */
+  n = (int32_t) in;
+
+  /* Make negative values towards -infinity */
+  if (in < 0.0f)
+  {
+    n--;
+  }
+
+  /* Map input value to [0 1] */
+  in = in - (float32_t) n;
+
+  /* Calculation of index of the table */
+  findex = (float32_t) FAST_MATH_TABLE_SIZE * in;
+  index = ((uint16_t)findex) & 0x1ff;
+
+  /* fractional value calculation */
+  fract = findex - (float32_t) index;
+
+  /* Read two nearest values of input value from the cos table */
+  a = sinTable_f32[index];
+  b = sinTable_f32[index+1];
+
+  /* Linear interpolation process */
+  cosVal = (1.0f-fract)*a + fract*b;
+
+  /* Return the output value */
+  return (cosVal);
+}
+
+/**
+ * @} end of cos group
+ */

--- a/Firmware/MotorControl/arm_cos_f32.c
+++ b/Firmware/MotorControl/arm_cos_f32.c
@@ -94,8 +94,14 @@ float32_t our_arm_cos_f32(
   in = in - (float32_t) n;
 
   /* Calculation of index of the table */
-  findex = (float32_t) FAST_MATH_TABLE_SIZE * in;
-  index = ((uint16_t)findex) & 0x1ff;
+  findex = (float32_t)FAST_MATH_TABLE_SIZE * in;
+  index = (uint16_t)findex;
+
+  /* when "in" is exactly 1, we need to rotate the index down to 0 */
+  if (index >= FAST_MATH_TABLE_SIZE) {
+    index = 0;
+    findex -= (float32_t)FAST_MATH_TABLE_SIZE;
+  }
 
   /* fractional value calculation */
   fract = findex - (float32_t) index;

--- a/Firmware/MotorControl/arm_sin_f32.c
+++ b/Firmware/MotorControl/arm_sin_f32.c
@@ -79,11 +79,6 @@ float32_t our_arm_sin_f32(
   int32_t n;
   float32_t findex;
 
-  /* Special case for small negative inputs */
-  if ((x < 0.0f) && (x >= -1.9e-7f)) {
-     return x;
-  }
-
   /* input x is in radians */
   /* Scale the input to [0 1] range from [0 2*PI] , divide input by 2*pi */
   in = x * 0.159154943092f;
@@ -101,8 +96,14 @@ float32_t our_arm_sin_f32(
   in = in - (float32_t) n;
 
   /* Calculation of index of the table */
-  findex = (float32_t) FAST_MATH_TABLE_SIZE * in;
-  index = ((uint16_t)findex) & 0x1ff;
+  findex = (float32_t)FAST_MATH_TABLE_SIZE * in;
+  index = (uint16_t)findex;
+
+  /* when "in" is exactly 1, we need to rotate the index down to 0 */
+  if (index >= FAST_MATH_TABLE_SIZE) {
+    index = 0;
+    findex -= (float32_t)FAST_MATH_TABLE_SIZE;
+  }
 
   /* fractional value calculation */
   fract = findex - (float32_t) index;

--- a/Firmware/MotorControl/arm_sin_f32.c
+++ b/Firmware/MotorControl/arm_sin_f32.c
@@ -1,0 +1,123 @@
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS DSP Library
+ * Title:        arm_sin_f32.c
+ * Description:  Fast sine calculation for floating-point values
+ *
+ * $Date:        27. January 2017
+ * $Revision:    V.1.5.1
+ *
+ * Target Processor: Cortex-M cores
+ * -------------------------------------------------------------------- */
+/*
+ * Copyright (C) 2010-2017 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stm32f4xx_hal.h>  // Sets up the correct chip specifc defines required by arm_math
+#define ARM_MATH_CM4 // TODO: might change in future board versions
+#include "arm_math.h"
+#include "arm_common_tables.h"
+
+/**
+ * @ingroup groupFastMath
+ */
+
+/**
+ * @defgroup sin Sine
+ *
+ * Computes the trigonometric sine function using a combination of table lookup
+ * and linear interpolation.  There are separate functions for
+ * Q15, Q31, and floating-point data types.
+ * The input to the floating-point version is in radians and in the range [0 2*pi) while the
+ * fixed-point Q15 and Q31 have a scaled input with the range
+ * [0 +0.9999] mapping to [0 2*pi).  The fixed-point range is chosen so that a
+ * value of 2*pi wraps around to 0.
+ *
+ * The implementation is based on table lookup using 256 values together with linear interpolation.
+ * The steps used are:
+ *  -# Calculation of the nearest integer table index
+ *  -# Compute the fractional portion (fract) of the table index.
+ *  -# The final result equals <code>(1.0f-fract)*a + fract*b;</code>
+ *
+ * where
+ * <pre>
+ *    b=Table[index+0];
+ *    c=Table[index+1];
+ * </pre>
+ */
+
+/**
+ * @addtogroup sin
+ * @{
+ */
+
+/**
+ * @brief  Fast approximation to the trigonometric sine function for floating-point data.
+ * @param[in] x input value in radians.
+ * @return  sin(x).
+ */
+
+float32_t our_arm_sin_f32(
+  float32_t x)
+{
+  float32_t sinVal, fract, in;                           /* Temporary variables for input, output */
+  uint16_t index;                                        /* Index variable */
+  float32_t a, b;                                        /* Two nearest output values */
+  int32_t n;
+  float32_t findex;
+
+  /* Special case for small negative inputs */
+  if ((x < 0.0f) && (x >= -1.9e-7f)) {
+     return x;
+  }
+
+  /* input x is in radians */
+  /* Scale the input to [0 1] range from [0 2*PI] , divide input by 2*pi */
+  in = x * 0.159154943092f;
+
+  /* Calculation of floor value of input */
+  n = (int32_t) in;
+
+  /* Make negative values towards -infinity */
+  if (x < 0.0f)
+  {
+    n--;
+  }
+
+  /* Map input value to [0 1] */
+  in = in - (float32_t) n;
+
+  /* Calculation of index of the table */
+  findex = (float32_t) FAST_MATH_TABLE_SIZE * in;
+  index = ((uint16_t)findex) & 0x1ff;
+
+  /* fractional value calculation */
+  fract = findex - (float32_t) index;
+
+  /* Read two nearest values of input value from the sin table */
+  a = sinTable_f32[index];
+  b = sinTable_f32[index+1];
+
+  /* Linear interpolation process */
+  sinVal = (1.0f-fract)*a + fract*b;
+
+  /* Return the output value */
+  return (sinVal);
+}
+
+/**
+ * @} end of sin group
+ */

--- a/Firmware/MotorControl/encoder.cpp
+++ b/Firmware/MotorControl/encoder.cpp
@@ -109,8 +109,8 @@ bool Encoder::run_index_search() {
     axis_->run_control_loop([&](){
         phase = wrap_pm_pi(phase + omega * current_meas_period);
 
-        float v_alpha = voltage_magnitude * arm_cos_f32(phase);
-        float v_beta = voltage_magnitude * arm_sin_f32(phase);
+        float v_alpha = voltage_magnitude * our_arm_cos_f32(phase);
+        float v_beta = voltage_magnitude * our_arm_sin_f32(phase);
         if (!axis_->motor_.enqueue_voltage_timings(v_alpha, v_beta))
             return false; // error set inside enqueue_voltage_timings
         axis_->motor_.log_timing(Motor::TIMING_LOG_IDX_SEARCH);
@@ -167,8 +167,8 @@ bool Encoder::run_offset_calibration() {
     i = 0;
     axis_->run_control_loop([&](){
         float phase = wrap_pm_pi(scan_distance * (float)i / (float)num_steps - scan_distance / 2.0f);
-        float v_alpha = voltage_magnitude * arm_cos_f32(phase);
-        float v_beta = voltage_magnitude * arm_sin_f32(phase);
+        float v_alpha = voltage_magnitude * our_arm_cos_f32(phase);
+        float v_beta = voltage_magnitude * our_arm_sin_f32(phase);
         if (!axis_->motor_.enqueue_voltage_timings(v_alpha, v_beta))
             return false; // error set inside enqueue_voltage_timings
         axis_->motor_.log_timing(Motor::TIMING_LOG_ENC_CALIB);
@@ -208,8 +208,8 @@ bool Encoder::run_offset_calibration() {
     i = 0;
     axis_->run_control_loop([&](){
         float phase = wrap_pm_pi(-scan_distance * (float)i / (float)num_steps + scan_distance / 2.0f);
-        float v_alpha = voltage_magnitude * arm_cos_f32(phase);
-        float v_beta = voltage_magnitude * arm_sin_f32(phase);
+        float v_alpha = voltage_magnitude * our_arm_cos_f32(phase);
+        float v_beta = voltage_magnitude * our_arm_sin_f32(phase);
         if (!axis_->motor_.enqueue_voltage_timings(v_alpha, v_beta))
             return false; // error set inside enqueue_voltage_timings
         axis_->motor_.log_timing(Motor::TIMING_LOG_ENC_CALIB);

--- a/Firmware/MotorControl/motor.cpp
+++ b/Firmware/MotorControl/motor.cpp
@@ -290,8 +290,8 @@ bool Motor::enqueue_voltage_timings(float v_alpha, float v_beta) {
 // TODO: This doesn't update brake current
 // We should probably make FOC Current call FOC Voltage to avoid duplication.
 bool Motor::FOC_voltage(float v_d, float v_q, float phase) {
-    float c = arm_cos_f32(phase);
-    float s = arm_sin_f32(phase);
+    float c = our_arm_cos_f32(phase);
+    float s = our_arm_sin_f32(phase);
     float v_alpha = c*v_d - s*v_q;
     float v_beta  = c*v_q + s*v_d;
     return enqueue_voltage_timings(v_alpha, v_beta);
@@ -308,8 +308,8 @@ bool Motor::FOC_current(float Id_des, float Iq_des, float phase) {
     float Ibeta = one_by_sqrt3 * (current_meas_.phB - current_meas_.phC);
 
     // Park transform
-    float c = arm_cos_f32(phase);
-    float s = arm_sin_f32(phase);
+    float c = our_arm_cos_f32(phase);
+    float s = our_arm_sin_f32(phase);
     float Id = c * Ialpha + s * Ibeta;
     float Iq = c * Ibeta - s * Ialpha;
     ictrl->Iq_measured = Iq;

--- a/Firmware/MotorControl/utils.h
+++ b/Firmware/MotorControl/utils.h
@@ -99,12 +99,13 @@ int mod(int dividend, int divisor);
 
 uint32_t deadline_to_timeout(uint32_t deadline_ms);
 uint32_t timeout_to_deadline(uint32_t timeout_ms);
-
 int is_in_the_future(uint32_t time_ms);
 
 uint32_t micros(void);
-
 void delay_us(uint32_t us);
+
+float our_arm_sin_f32(float x);
+float our_arm_cos_f32(float x);
 
 #ifdef __cplusplus
 }

--- a/Firmware/Tupfile.lua
+++ b/Firmware/Tupfile.lua
@@ -105,6 +105,7 @@ LDFLAGS += '-Wl,--undefined=uxTopUsedPriority'
 
 -- common flags for ASM, C and C++
 OPT += '-Og'
+-- OPT += '-O0'
 OPT += '-ffast-math -fno-finite-math-only'
 tup.append_table(FLAGS, OPT)
 tup.append_table(LDFLAGS, OPT)
@@ -148,6 +149,8 @@ build{
     sources={
         'Drivers/DRV8301/drv8301.c',
         'MotorControl/utils.c',
+        'MotorControl/arm_sin_f32.c',
+        'MotorControl/arm_cos_f32.c',
         'MotorControl/low_level.cpp',
         'MotorControl/nvm.c',
         'MotorControl/axis.cpp',

--- a/ODrive_Workspace.code-workspace
+++ b/ODrive_Workspace.code-workspace
@@ -44,7 +44,8 @@
 			"algorithm": "cpp",
 			"chrono": "cpp",
 			"condition_variable": "cpp",
-			"future": "cpp"
+			"future": "cpp",
+			"arm_math.h": "c"
 		}
 	}
 }


### PR DESCRIPTION
There is a [bug](https://github.com/ARM-software/CMSIS_5/issues/267) in the arm fast math library, which gives spikes in the output of arm_cos_f32 for input values close to -pi/2. I submitted [a fix](https://github.com/ARM-software/CMSIS_5/pull/439) to the ARM CMSIS repo.

This PR implements that fix locally to us while we wait for it to be accepted upstream.