### PR TITLE
Added RC PWM mixer for differential steering and PWM deadband.

### DIFF
--- a/Firmware/MotorControl/odrive_main.h
+++ b/Firmware/MotorControl/odrive_main.h
@@ -64,6 +64,7 @@ struct PWMMapping_t {
     endpoint_ref_t endpoint = { 0 };
     float min = 0;
     float max = 0;
+    bool enable_deadband = true;
 };
 
 struct DiffSteeringMixerMapping_t {

--- a/Firmware/MotorControl/odrive_main.h
+++ b/Firmware/MotorControl/odrive_main.h
@@ -66,6 +66,16 @@ struct PWMMapping_t {
     float max = 0;
 };
 
+struct DiffSteeringMixerMapping_t {
+    endpoint_ref_t endpoint_output_a = { 0 };
+    endpoint_ref_t endpoint_output_b = { 0 };
+    float input_steering = 0;
+    float input_throttle = 0;
+    float direction_a = 1;
+    float direction_b = -1;
+    int32_t gpio_update_trigger = 0;
+};
+
 // @brief general user configurable board configuration
 struct BoardConfig_t {
     bool enable_uart = true;
@@ -82,6 +92,7 @@ struct BoardConfig_t {
                                                                         //<! the brake power if the brake resistor is disabled.
                                                                         //<! The default is 26V for the 24V board version and 52V for the 48V board version.
     PWMMapping_t pwm_mappings[GPIO_COUNT];
+    DiffSteeringMixerMapping_t mixer_mapping;
 };
 extern BoardConfig_t board_config;
 extern bool user_config_loaded_;

--- a/Firmware/communication/communication.cpp
+++ b/Firmware/communication/communication.cpp
@@ -74,7 +74,8 @@ auto make_protocol_definitions(PWMMapping_t& mapping) {
     return make_protocol_member_list(
         make_protocol_property("endpoint", &mapping.endpoint),
         make_protocol_property("min", &mapping.min),
-        make_protocol_property("max", &mapping.max)
+        make_protocol_property("max", &mapping.max),
+        make_protocol_property("enable_deadband", &mapping.enable_deadband)
     );
 }
 

--- a/Firmware/communication/communication.cpp
+++ b/Firmware/communication/communication.cpp
@@ -78,6 +78,18 @@ auto make_protocol_definitions(PWMMapping_t& mapping) {
     );
 }
 
+auto make_protocol_definitions(DiffSteeringMixerMapping_t& mapping) {
+    return make_protocol_member_list(
+        make_protocol_property("input_throttle", &mapping.input_throttle),
+        make_protocol_property("input_steering", &mapping.input_steering),
+        make_protocol_property("endpoint_output_a", &mapping.endpoint_output_a),
+        make_protocol_property("endpoint_output_b", &mapping.endpoint_output_b),
+        make_protocol_property("direction_a", &mapping.direction_a),
+        make_protocol_property("direction_b", &mapping.direction_b),
+        make_protocol_property("gpio_update_trigger", &mapping.gpio_update_trigger)
+    );
+}
+
 /* Function implementations --------------------------------------------------*/
 
 void init_communication(void) {
@@ -163,7 +175,8 @@ static inline auto make_obj_tree() {
             make_protocol_object("gpio2_pwm_mapping", make_protocol_definitions(board_config.pwm_mappings[1])),
             make_protocol_object("gpio3_pwm_mapping", make_protocol_definitions(board_config.pwm_mappings[2])),
 #endif
-            make_protocol_object("gpio4_pwm_mapping", make_protocol_definitions(board_config.pwm_mappings[3]))
+            make_protocol_object("gpio4_pwm_mapping", make_protocol_definitions(board_config.pwm_mappings[3])),
+            make_protocol_object("diff_steering_mixer_mapping", make_protocol_definitions(board_config.mixer_mapping))
         ),
         make_protocol_object("axis0", axes[0]->make_protocol_definitions()),
         make_protocol_object("axis1", axes[1]->make_protocol_definitions()),

--- a/Firmware/communication/communication.cpp
+++ b/Firmware/communication/communication.cpp
@@ -97,7 +97,7 @@ void init_communication(void) {
     printf("hi!\r\n");
 
     // Start command handling thread
-    osThreadDef(task_cmd_parse, communication_task, osPriorityNormal, 0, 5000 /* in 32-bit words */); // TODO: fix stack issues
+    osThreadDef(task_cmd_parse, communication_task, osPriorityNormal, 0, 6000 /* in 32-bit words */); // TODO: fix stack issues
     comm_thread = osThreadCreate(osThread(task_cmd_parse), NULL);
 
     while (!endpoint_list_valid)

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -125,6 +125,8 @@ As an example, we'll configure GPIO4 to control the angle of axis 0. We want the
     ```
 5. With the ODrive powered off, connect the RC receiver ground to the ODrive's GND and one of the RC receiver signals to GPIO4. You may try to power the receiver from the ODrive's 5V supply if it doesn't draw too much power. Power up the the RC transmitter. You should now be able to control axis 0 from one of the RC sticks.
 
+The PWM pins have a center deadband that's enabled by default to control creeping when using the pins for velocity or current control.  When the RC PWM pulse time is in the 1495μs to 1505μs range, the endpoint is set to a constant halfway between the `gpioN_pwm_mapping.min` and `max` settings.  Change `gpioN_pwm_mapping.enable_deadband` to `False` to disable it.
+
 ### Differential Steering Mixer
 An input mixer meant for controlling skid-steer or differential-steering robots is also available.  It takes inputs from a steering and a throttle channel and converts them outputs for left and right motors.
 


### PR DESCRIPTION
I've added a mixer that uses fibre endpoints for configuration.  Users can route the PWM signals to the mixer and then the mixer outputs to control parameters.

Here's the math inside the function:
endpoint_a = direction_a * (input_throttle + input_steering));
endpoint_b = direction_b * (input_throttle - input_steering));

I've tested it with a pistol-grip style transmitter and a hoverboard cart and I'm happy with the way it responds.

The PWM deadband feature adds a region from 1495μs to 1505μs where the value outputted is (min + max)/2.  Since this might not be useful for some applications, it has toggle to disable.