### PR TITLE
Frequency domain anticogging map storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,12 @@ tup.config
 /_site
 /.bundle
 
+# QtCreator
+Firmware/*\.config
+Firmware/*\.creator
+Firmware/*\.creator\.user
+Firmware/*\.files
+Firmware/*\.includes
+
+#PyCharm
+tools/\.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -42,11 +42,11 @@ tup.config
 /.bundle
 
 # QtCreator
-Firmware/*\.config
-Firmware/*\.creator
-Firmware/*\.creator\.user
-Firmware/*\.files
-Firmware/*\.includes
+*\.config
+*\.creator
+*\.creator\.user
+*\.files
+*\.includes
 
 #PyCharm
 tools/\.idea/

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -236,6 +236,8 @@ void Axis::run_state_machine_loop() {
         for (int i = 0; i < encoder_cpr; i++) {
             controller_.anticogging_.cogging_map[i] = 0.0f;
         }
+        //-- Do the inverse FFT to generate the anticogging map
+        controller_.init_anticogging_map();
     }
 
     // arm!

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -248,7 +248,7 @@ void Axis::run_state_machine_loop() {
             if (requested_state_ == AXIS_STATE_STARTUP_SEQUENCE) {
                 if (config_.startup_motor_calibration)
                     task_chain_[pos++] = AXIS_STATE_MOTOR_CALIBRATION;
-                if (config_.startup_encoder_index_search && encoder_.config_.use_index)
+                if (config_.startup_encoder_index_search)
                     task_chain_[pos++] = AXIS_STATE_ENCODER_INDEX_SEARCH;
                 if (config_.startup_encoder_offset_calibration)
                     task_chain_[pos++] = AXIS_STATE_ENCODER_OFFSET_CALIBRATION;

--- a/Firmware/MotorControl/controller.cpp
+++ b/Firmware/MotorControl/controller.cpp
@@ -86,6 +86,7 @@ bool Controller::anticogging_calibration(float pos_estimate, float vel_estimate)
         } else {
             anticogging_.index = 0;
             set_pos_setpoint(0.0f, 0.0f, 0.0f);  // Send the motor home
+            extract_harmonics();
             anticogging_.use_anticogging = true;  // We're good to go, enable anti-cogging
             anticogging_.calib_anticogging = false;
             return true;
@@ -93,7 +94,85 @@ bool Controller::anticogging_calibration(float pos_estimate, float vel_estimate)
     }
     return false;
 }
+/*
+ * This function takes the cogging map in the 'time' domain, performs an FFT,
+ * finds the frequencies with the highest magnitudes (ignoring zero) and saves them to
+ * the config structure.
+ */
+void Controller::extract_harmonics(){
+    int32_t fft_size = axis_->encoder_.config_.cpr;
 
+    // Determine what sized fft to use:
+    // TODO: Handle non power series of two FFTs
+    // TODO: We could do this with RFFTs
+    const arm_cfft_instance_f32 *S;
+    switch (fft_size) {
+      case 512:  S = &arm_cfft_sR_f32_len512;  break;
+      case 1024: S = &arm_cfft_sR_f32_len1024; break;
+      case 2048: S = &arm_cfft_sR_f32_len2048; break;
+      case 4096: S = &arm_cfft_sR_f32_len4096; break;
+    };
+
+    float *fft_array = (float*)malloc(2 * fft_size * sizeof(float));
+    float *mag_array = (float*)malloc((fft_size /2) * sizeof(float));
+
+    for(int i = 0; i < fft_size; i++){
+        fft_array[i*2] = anticogging_.cogging_map[i];
+        fft_array[(i*2)+1] = 0;
+    }
+
+    arm_cfft_f32(S, fft_array, 0, 1);
+    // real ffts are symmetric, we dont need half this array...
+    arm_cmplx_mag_f32(fft_array, mag_array, fft_size/2);
+
+    // ignore the DC component
+    mag_array[0] = 0;
+
+    // we need to find the NUM_HARMONICS highest magnitudes
+    uint32_t indices[NUM_HARMONICS];
+    find_n_highest_indices(mag_array, fft_size/2, indices, NUM_HARMONICS);
+    
+    for (int i = 0; i < NUM_HARMONICS; i++){
+        uint32_t index = indices[i];
+        config_.harmonics[i].index = index;
+        config_.harmonics[i].real = fft_array[index *2];
+        config_.harmonics[i].imaginary = fft_array[(index*2) +1];
+    }
+
+    free(fft_array);
+    free(mag_array);
+}
+/*
+ * Find the indices of the n highest values in an array
+ */
+void Controller::find_n_highest_indices(float* arr, uint32_t arr_size, uint32_t* indices, uint32_t n){
+    float *min_sorted_maxes = (float*)malloc(n * sizeof(float));
+
+    for(uint32_t i = 0; i < n-1; i++){
+        min_sorted_maxes[i] = 0;
+        indices[i] = 0;
+    }
+    min_sorted_maxes[n-1] = arr[0];
+    indices[n-1] = 0;
+
+    for(uint32_t i = 1; i < arr_size; i++){
+        float val = arr[i];
+        if(val > min_sorted_maxes[0]){
+            for(uint32_t j = 1; j <= n; j++){
+                if((j < n) && (val > min_sorted_maxes[j])){
+                    min_sorted_maxes[j-1] = min_sorted_maxes[j];
+                    indices[j-1] = indices[j];
+                }
+                else{
+                    min_sorted_maxes[j-1] = val;
+                    indices[j-1] = i;
+                    break;
+                }
+            }
+        }
+    }
+    free(min_sorted_maxes);
+}
 float Controller::write_harmonics(int32_t index, int32_t harmonic, int32_t imag, float value){
     if (!std::isnan(value)){
         config_.harmonics[index].index = harmonic;

--- a/Firmware/MotorControl/controller.cpp
+++ b/Firmware/MotorControl/controller.cpp
@@ -93,6 +93,12 @@ bool Controller::anticogging_calibration(float pos_estimate, float vel_estimate)
     return false;
 }
 
+float Controller::write_anticogging_map(int32_t index, float value){
+    if (anticogging_.cogging_map != NULL && !std::isnan(value))
+        anticogging_.cogging_map[index] = value;
+    return anticogging_.cogging_map[index];
+}
+
 bool Controller::update(float pos_estimate, float vel_estimate, float* current_setpoint_output) {
     // Only runs if anticogging_.calib_anticogging is true; non-blocking
     anticogging_calibration(pos_estimate, vel_estimate);

--- a/Firmware/MotorControl/controller.cpp
+++ b/Firmware/MotorControl/controller.cpp
@@ -94,6 +94,14 @@ bool Controller::anticogging_calibration(float pos_estimate, float vel_estimate)
     return false;
 }
 
+float Controller::write_harmonics(int32_t index, int32_t harmonic, int32_t imag, float value){
+    if (!std::isnan(value)){
+        config_.harmonics[index].index = harmonic;
+        imag ? config_.harmonics[index].imaginary = value : config_.harmonics[index].real = value;
+    }
+    return imag ? config_.harmonics[index].imaginary: config_.harmonics[index].real;
+}
+
 float Controller::write_anticogging_map(int32_t index, float value){
     if (anticogging_.cogging_map != NULL && !std::isnan(value))
         anticogging_.cogging_map[index] = value;

--- a/Firmware/MotorControl/controller.hpp
+++ b/Firmware/MotorControl/controller.hpp
@@ -56,6 +56,8 @@ public:
     // TODO: make this more similar to other calibration loops
     void start_anticogging_calibration();
     bool anticogging_calibration(float pos_estimate, float vel_estimate);
+    void extract_harmonics();
+    void find_n_highest_indices(float* arr, uint32_t arr_size, uint32_t* indices, uint32_t n);
     float write_anticogging_map(int32_t index, float value);
     float write_harmonics(int32_t index, int32_t harmonic, int32_t imag, float value);
     void init_anticogging_map();

--- a/Firmware/MotorControl/controller.hpp
+++ b/Firmware/MotorControl/controller.hpp
@@ -48,6 +48,7 @@ public:
     // TODO: make this more similar to other calibration loops
     void start_anticogging_calibration();
     bool anticogging_calibration(float pos_estimate, float vel_estimate);
+    float write_anticogging_map(int32_t index, float value);
 
     bool update(float pos_estimate, float vel_estimate, float* current_setpoint);
 
@@ -107,6 +108,7 @@ public:
                 make_protocol_property("vel_limit", &config_.vel_limit),
                 make_protocol_property("vel_limit_tolerance", &config_.vel_limit_tolerance),
                 make_protocol_property("vel_ramp_limit", &config_.vel_ramp_limit),
+                make_protocol_property("use_anticogging", &anticogging_.use_anticogging),
                 make_protocol_property("setpoints_in_cpr", &config_.setpoints_in_cpr)
             ),
             make_protocol_function("set_pos_setpoint", *this, &Controller::set_pos_setpoint,
@@ -116,6 +118,8 @@ public:
             make_protocol_function("set_current_setpoint", *this, &Controller::set_current_setpoint,
                 "current_setpoint"),
             make_protocol_function("move_to_pos", *this, &Controller::move_to_pos, "goal_point"),
+            make_protocol_function("write_anticogging_map", *this, &Controller::write_anticogging_map,
+                "index", "value"),
             make_protocol_function("start_anticogging_calibration", *this, &Controller::start_anticogging_calibration)
         );
     }

--- a/Firmware/MotorControl/controller.hpp
+++ b/Firmware/MotorControl/controller.hpp
@@ -22,6 +22,13 @@ public:
         CTRL_MODE_TRAJECTORY_CONTROL = 4
     };
 
+    static const int32_t NUM_HARMONICS = 16;
+    typedef struct {
+        uint32_t index;
+        float real;
+        float imaginary;
+    }Harmonic_t ;
+
     struct Config_t {
         ControlMode_t control_mode = CTRL_MODE_POSITION_CONTROL;  //see: Motor_control_mode_t
         float pos_gain = 20.0f;  // [(counts/s) / counts]
@@ -32,6 +39,7 @@ public:
         float vel_limit_tolerance = 1.2f;  // ratio to vel_lim. 0.0f to disable
         float vel_ramp_limit = 10000.0f;  // [(counts/s) / s]
         bool setpoints_in_cpr = false;
+        Harmonic_t harmonics[NUM_HARMONICS];
     };
 
     Controller(Config_t& config);
@@ -49,6 +57,7 @@ public:
     void start_anticogging_calibration();
     bool anticogging_calibration(float pos_estimate, float vel_estimate);
     float write_anticogging_map(int32_t index, float value);
+    void init_anticogging_map();
 
     bool update(float pos_estimate, float vel_estimate, float* current_setpoint);
 
@@ -120,6 +129,7 @@ public:
             make_protocol_function("move_to_pos", *this, &Controller::move_to_pos, "goal_point"),
             make_protocol_function("write_anticogging_map", *this, &Controller::write_anticogging_map,
                 "index", "value"),
+            make_protocol_function("init_anticogging_map", *this, &Controller::init_anticogging_map),
             make_protocol_function("start_anticogging_calibration", *this, &Controller::start_anticogging_calibration)
         );
     }

--- a/Firmware/MotorControl/controller.hpp
+++ b/Firmware/MotorControl/controller.hpp
@@ -57,6 +57,7 @@ public:
     void start_anticogging_calibration();
     bool anticogging_calibration(float pos_estimate, float vel_estimate);
     float write_anticogging_map(int32_t index, float value);
+    float write_harmonics(int32_t index, int32_t harmonic, int32_t imag, float value);
     void init_anticogging_map();
 
     bool update(float pos_estimate, float vel_estimate, float* current_setpoint);
@@ -129,6 +130,8 @@ public:
             make_protocol_function("move_to_pos", *this, &Controller::move_to_pos, "goal_point"),
             make_protocol_function("write_anticogging_map", *this, &Controller::write_anticogging_map,
                 "index", "value"),
+            make_protocol_function("write_harmonics", *this, &Controller::write_harmonics,
+                        "index", "harmonic", "imag", "value"),
             make_protocol_function("init_anticogging_map", *this, &Controller::init_anticogging_map),
             make_protocol_function("start_anticogging_calibration", *this, &Controller::start_anticogging_calibration)
         );

--- a/Firmware/MotorControl/encoder.hpp
+++ b/Firmware/MotorControl/encoder.hpp
@@ -51,7 +51,7 @@ public:
 
     void enc_index_cb();
 
-    void enc_pwm_cb(uint32_t high_time);
+    void enc_pwm_cb(uint32_t rise_time, uint32_t fall_time);
 
     void set_linear_count(int32_t count);
     void set_circular_count(int32_t count, bool update_offset);
@@ -70,7 +70,7 @@ public:
 
     Error_t error_ = ERROR_NONE;
     bool index_found_ = false;
-    bool pwm_updated = false;
+    bool pwm_updated_ = false;
     bool is_ready_ = false;
     int32_t shadow_count_ = 0;
     int32_t count_in_cpr_ = 0;

--- a/Firmware/MotorControl/encoder.hpp
+++ b/Firmware/MotorControl/encoder.hpp
@@ -19,12 +19,15 @@ public:
 
     enum Mode_t {
         MODE_INCREMENTAL,
+        MODE_INCREMENTAL_PWM,
+        MODE_ABSOLUTE,
         MODE_HALL
     };
 
     struct Config_t {
         Encoder::Mode_t mode = Encoder::MODE_INCREMENTAL;
         bool use_index = false;
+        int32_t pwm_pin = 0;    // GPIO pin of the absolue PWM signal, must be 4 or 5
         bool pre_calibrated = false; // If true, this means the offset stored in
                                     // configuration is valid and does not need
                                     // be determined by run_offset_calibration.
@@ -48,6 +51,8 @@ public:
 
     void enc_index_cb();
 
+    void enc_pwm_cb(uint32_t high_time);
+
     void set_linear_count(int32_t count);
     void set_circular_count(int32_t count, bool update_offset);
     bool calib_enc_offset(float voltage_magnitude);
@@ -65,6 +70,7 @@ public:
 
     Error_t error_ = ERROR_NONE;
     bool index_found_ = false;
+    bool pwm_updated = false;
     bool is_ready_ = false;
     int32_t shadow_count_ = 0;
     int32_t count_in_cpr_ = 0;
@@ -75,6 +81,7 @@ public:
     float vel_estimate_ = 0.0f;  // [count/s]
     float pll_kp_ = 0.0f;   // [count/s / count]
     float pll_ki_ = 0.0f;   // [(count/s^2) / count]
+    int32_t pos_abs_ = 0;
 
     // Updated by low_level pwm_adc_cb
     uint8_t hall_state_ = 0x0; // bit[0] = HallA, .., bit[2] = HallC
@@ -93,11 +100,13 @@ public:
             make_protocol_property("pos_cpr", &pos_cpr_),
             make_protocol_property("hall_state", &hall_state_),
             make_protocol_property("vel_estimate", &vel_estimate_),
+            make_protocol_property("pos_abs", &pos_abs_),
             // make_protocol_property("pll_kp", &pll_kp_),
             // make_protocol_property("pll_ki", &pll_ki_),
             make_protocol_object("config",
                 make_protocol_property("mode", &config_.mode),
                 make_protocol_property("use_index", &config_.use_index),
+                make_protocol_property("pwm_pin", &config_.pwm_pin),
                 make_protocol_property("pre_calibrated", &config_.pre_calibrated),
                 make_protocol_property("idx_search_speed", &config_.idx_search_speed),
                 make_protocol_property("zero_count_on_find_idx", &config_.zero_count_on_find_idx),

--- a/Firmware/MotorControl/low_level.cpp
+++ b/Firmware/MotorControl/low_level.cpp
@@ -714,7 +714,7 @@ void pwm_in_cb(int channel, uint32_t timestamp) {
         // Check if this pin is used for absolute pwm positioning
         for (size_t i = 0; i < AXIS_COUNT; ++i)
             if(axes[i]->encoder_.config_.pwm_pin == gpio_num)
-                axes[i]->encoder_.enc_pwm_cb(timestamp - last_timestamp[gpio_num - 1]);
+                axes[i]->encoder_.enc_pwm_cb(last_timestamp[gpio_num - 1], timestamp);
     }
 
     last_timestamp[gpio_num - 1] = timestamp;


### PR DESCRIPTION
This implements storage of a finite number of frequency domain harmonics that describe the anticogging map.

The FFT / IFFT are perfomed using Arm CMSIS-DSP functions.


Currently only power series of two CPRs are supported.

This relies on knowing the absolute position of the motor.