### PR TITLE
Fix issues with spaces in install path on windows

### DIFF
--- a/tools/odrivetool.bat
+++ b/tools/odrivetool.bat
@@ -1,2 +1,2 @@
 @echo off
-ipython %~dp0\odrivetool -- %*
+ipython "%~dp0\odrivetool" -- %*


### PR DESCRIPTION
This commit fixes issues on windows when you have spaces in the file path (i.e., when python3 gets installed to App Data under a user with a space in their name) 