### PR TITLE
Adding preliminary support for SPI absolute encoders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,13 @@ tup.config
 /_site
 /.bundle
 
+
+ODrive\.config
+
+ODrive\.creator
+
+ODrive\.creator\.user
+
+ODrive\.files
+
+ODrive\.includes

--- a/Firmware/MotorControl/board_config_v3.h
+++ b/Firmware/MotorControl/board_config_v3.h
@@ -36,6 +36,7 @@ typedef struct {
     uint16_t hallB_pin;
     GPIO_TypeDef* hallC_port;
     uint16_t hallC_pin;
+    SPI_HandleTypeDef* spi;
 } EncoderHardwareConfig_t;
 typedef struct {
     TIM_HandleTypeDef* timer;
@@ -86,6 +87,7 @@ const BoardHardwareConfig_t hw_configs[2] = { {
         .hallB_pin = M0_ENC_B_Pin,
         .hallC_port = M0_ENC_Z_GPIO_Port,
         .hallC_pin = M0_ENC_Z_Pin,
+        .spi = &hspi3,
     },
     .motor_config = {
         .timer = &htim1,
@@ -125,6 +127,7 @@ const BoardHardwareConfig_t hw_configs[2] = { {
         .hallB_pin = M1_ENC_B_Pin,
         .hallC_port = M1_ENC_Z_GPIO_Port,
         .hallC_pin = M1_ENC_Z_Pin,
+        .spi = &hspi3,
     },
     .motor_config = {
         .timer = &htim8,

--- a/Firmware/MotorControl/encoder.cpp
+++ b/Firmware/MotorControl/encoder.cpp
@@ -281,7 +281,7 @@ bool Encoder::abs_spi_init(){
     spi->Init.CLKPolarity = SPI_POLARITY_LOW;
     spi->Init.CLKPhase = SPI_PHASE_2EDGE;
     spi->Init.NSS = SPI_NSS_SOFT;
-    spi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
+    spi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32;
     spi->Init.FirstBit = SPI_FIRSTBIT_MSB;
     spi->Init.TIMode = SPI_TIMODE_DISABLE;
     spi->Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
@@ -324,21 +324,24 @@ void Encoder::abs_spi_cb(){
     HAL_GPIO_WritePin(abs_spi_cs_port_, abs_spi_cs_pin_, GPIO_PIN_SET);
     switch (config_.mode) {
         case MODE_SPI_ABS_AMS: {
-            //TODO check parity
         uint8_t parity_calc, parity_bit;
         parity_calc = parity(abs_spi_dma_rx_[0]&0x7FFF);
         parity_bit = abs_spi_dma_rx_[0] >>15;
-            if(parity_calc != parity_bit)
-                set_error(ERROR_ABS_SPI_COM_FAIL);
+
+        if(parity_calc == parity_bit){
             pos_abs_ = abs_spi_dma_rx_[0] & 0x3FFF;
+            // We are going to ignore values all high or low
+            // This might happen in normal operation, but its unlikely
+            // The filter will handle these cases
+            if(pos_abs_ != 0  && pos_abs_ != 0x3FFF)
+                abs_spi_pos_updated_ = true;
+        }
         }break;
 
         default: {
            set_error(ERROR_UNSUPPORTED_ENCODER_MODE);
         } break;
     }
-
-    abs_spi_pos_updated_ = true;
     is_ready_ = true;
 }
 
@@ -377,8 +380,15 @@ bool Encoder::update() {
         case MODE_SPI_ABS_AMS:
         case MODE_SPI_ABS_CUI:{
             if(abs_spi_pos_updated_ == false){
-                set_error(ERROR_ABS_SPI_TIMEOUT);
+                // Low pass filter the error
+                spi_error_rate_ += current_meas_period * (1.0f - spi_error_rate_);
+                if (spi_error_rate_ > 0.005f)
+                    set_error(ERROR_ABS_SPI_COM_FAIL);
             }
+            else
+                // Low pass filter the error
+                spi_error_rate_ += current_meas_period * (0.0f - spi_error_rate_);
+
             abs_spi_pos_updated_ = false;
             delta_enc = pos_abs_ - count_in_cpr_;
             delta_enc = mod(delta_enc, config_.cpr);

--- a/Firmware/MotorControl/encoder.hpp
+++ b/Firmware/MotorControl/encoder.hpp
@@ -84,6 +84,7 @@ public:
     float pll_kp_ = 0.0f;   // [count/s / count]
     float pll_ki_ = 0.0f;   // [(count/s^2) / count]
     int32_t pos_abs_ = 0;
+    float spi_error_rate_ = 0.0f;
 
     // Updated by low_level pwm_adc_cb
     uint8_t hall_state_ = 0x0; // bit[0] = HallA, .., bit[2] = HallC

--- a/Firmware/MotorControl/encoder.hpp
+++ b/Firmware/MotorControl/encoder.hpp
@@ -92,7 +92,7 @@ public:
     bool abs_spi_init();
     bool abs_spi_start_transaction();
     void abs_spi_cb();
-    void decode_abs_spi_cs_pin();
+    void abs_spi_cs_pin_init();
     uint16_t abs_spi_dma_tx_[2] = {0xFFFF, 0x0000};
     uint16_t abs_spi_dma_rx_[2];
     bool abs_spi_pos_updated_;
@@ -119,10 +119,11 @@ public:
             // make_protocol_property("pll_kp", &pll_kp_),
             // make_protocol_property("pll_ki", &pll_ki_),
             make_protocol_object("config",
-                make_protocol_property("mode", &config_.mode),
+                make_protocol_property("mode", &config_.mode,
+                    [](void* ctx) { static_cast<Encoder*>(ctx)->abs_spi_init(); }, this),
                 make_protocol_property("use_index", &config_.use_index),
                 make_protocol_property("abs_spi_cs_gpio_pin", &config_.abs_spi_cs_gpio_pin,
-                    [](void* ctx) { static_cast<Encoder*>(ctx)->decode_abs_spi_cs_pin(); }, this),
+                    [](void* ctx) { static_cast<Encoder*>(ctx)->abs_spi_cs_pin_init(); }, this),
                 make_protocol_property("pre_calibrated", &config_.pre_calibrated),
                 make_protocol_property("idx_search_speed", &config_.idx_search_speed),
                 make_protocol_property("zero_count_on_find_idx", &config_.zero_count_on_find_idx),

--- a/Firmware/MotorControl/encoder.hpp
+++ b/Firmware/MotorControl/encoder.hpp
@@ -15,8 +15,9 @@ public:
         ERROR_UNSUPPORTED_ENCODER_MODE = 0x08,
         ERROR_ILLEGAL_HALL_STATE = 0x10,
         ERROR_INDEX_NOT_FOUND_YET = 0x20,
-        ERROR_ABS_SPI_TIMEOUT = 0x30,
-        ERROR_ABS_SPI_COM_FAIL = 0x40,
+        ERROR_ABS_SPI_TIMEOUT = 0x40,
+        ERROR_ABS_SPI_COM_FAIL = 0x80,
+        ERROR_ABS_SPI_NOT_READY = 0x100,
     };
 
     enum Mode_t {

--- a/Firmware/MotorControl/low_level.cpp
+++ b/Firmware/MotorControl/low_level.cpp
@@ -496,6 +496,10 @@ void pwm_trig_adc_cb(ADC_HandleTypeDef* hadc, bool injected) {
             update_timings = true; // update timings of M0
         else if (&axis == axes[0] && !counting_down)
             update_timings = true; // update timings of M1
+
+        if(current_meas_not_DC_CAL){
+            axis.encoder_.abs_spi_start_transaction();
+        }
     }
 
     // Load next timings for the motor that we're not currently sampling
@@ -742,4 +746,10 @@ void start_analog_thread()
 {
     osThreadDef(thread_def, analog_polling_thread, osPriorityLow, 0, 4*512);
     osThreadCreate(osThread(thread_def), NULL);
+}
+
+
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+    axes[0]->encoder_.abs_spi_cb();
 }

--- a/Firmware/MotorControl/low_level.cpp
+++ b/Firmware/MotorControl/low_level.cpp
@@ -751,5 +751,8 @@ void start_analog_thread()
 
 void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
 {
-    axes[0]->encoder_.abs_spi_cb();
+    if(hspi->pRxBuffPtr == (uint8_t*)axes[0]->encoder_.abs_spi_dma_rx_)
+        axes[0]->encoder_.abs_spi_cb();
+    else if (hspi->pRxBuffPtr == (uint8_t*)axes[1]->encoder_.abs_spi_dma_rx_)
+        axes[1]->encoder_.abs_spi_cb();
 }

--- a/Firmware/MotorControl/low_level.cpp
+++ b/Firmware/MotorControl/low_level.cpp
@@ -497,7 +497,8 @@ void pwm_trig_adc_cb(ADC_HandleTypeDef* hadc, bool injected) {
         else if (&axis == axes[0] && !counting_down)
             update_timings = true; // update timings of M1
 
-        if(current_meas_not_DC_CAL){
+        if((current_meas_not_DC_CAL && !axis_num) ||
+                (axis_num && !current_meas_not_DC_CAL)){
             axis.encoder_.abs_spi_start_transaction();
         }
     }


### PR DESCRIPTION
Adding preliminary support for non-blocking SPI absolute encoders. 
This code uses HAL_SPI_TransmitReceive_DMA() to start an SPI transaction. 
The transaction is initiated from the ADC callback and the SPI transaction complete interrupt calls the encoders callback.
The callback sets a flag which is checked in the encoder update function. This may not be necessary.