### PR TITLE
Backend fixes

### DIFF
--- a/Firmware/.vscode/c_cpp_properties.json
+++ b/Firmware/.vscode/c_cpp_properties.json
@@ -28,16 +28,10 @@
                 "USB_PROTOCOL_NATIVE",
                 "__weak=\"__attribute__((weak))\"",
                 "__packed=\"__attribute__((__packed__))\"",
-                "__GNUC__"
+                "__GNUC__",
+                "__ODRIVE_MAIN_H"
             ],
             "intelliSenseMode": "clang-x64",
-            "browse": {
-                "path": [
-                    "${workspaceRoot}",
-                    "${ARM_GCC_ROOT}"
-                ],
-                "limitSymbolsToIncludedHeaders": true
-            },
             "compilerPath": "\"${ARM_GCC_ROOT}/bin/arm-none-eabi-gcc.exe\" -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -u _printf_float -u _scanf_float",
             "cStandard": "c11",
             "cppStandard": "c++14"

--- a/Firmware/.vscode/c_cpp_properties.json
+++ b/Firmware/.vscode/c_cpp_properties.json
@@ -28,8 +28,7 @@
                 "USB_PROTOCOL_NATIVE",
                 "__weak=\"__attribute__((weak))\"",
                 "__packed=\"__attribute__((__packed__))\"",
-                "__GNUC__",
-                "__ODRIVE_MAIN_H"
+                "__GNUC__"
             ],
             "intelliSenseMode": "clang-x64",
             "compilerPath": "\"${ARM_GCC_ROOT}/bin/arm-none-eabi-gcc.exe\" -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -u _printf_float -u _scanf_float",

--- a/Firmware/Board/v3/Src/freertos.c
+++ b/Firmware/Board/v3/Src/freertos.c
@@ -189,6 +189,7 @@ void MX_FREERTOS_Init(void) {
 
   init_deferred_interrupts();
 
+  // Load persistent configuration (or defaults)
   load_configuration();
   /* USER CODE END RTOS_SEMAPHORES */
 

--- a/Firmware/Board/v3/Src/freertos.c
+++ b/Firmware/Board/v3/Src/freertos.c
@@ -60,6 +60,7 @@
 #include "usb_device.h"
 extern PCD_HandleTypeDef hpcd_USB_OTG_FS;
 int odrive_main(void);
+int load_configuration(void);
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -187,6 +188,8 @@ void MX_FREERTOS_Init(void) {
   sem_usb_tx = osSemaphoreCreate(osSemaphore(sem_usb_tx), 1);
 
   init_deferred_interrupts();
+
+  load_configuration();
   /* USER CODE END RTOS_SEMAPHORES */
 
   /* USER CODE BEGIN RTOS_TIMERS */

--- a/Firmware/MotorControl/controller.hpp
+++ b/Firmware/MotorControl/controller.hpp
@@ -34,7 +34,7 @@ public:
         bool setpoints_in_cpr = false;
     };
 
-    Controller(Config_t& config);
+    explicit Controller(Config_t& config);
     void reset();
     void set_error(Error_t error);
 

--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -117,7 +117,6 @@ void vApplicationIdleHook(void) {
 }
 
 int odrive_main(void) {
-    // Load persistent configuration (or defaults)
 
 #if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 3
     if (board_config.enable_i2c_instead_of_can) {

--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -45,7 +45,7 @@ void save_configuration(void) {
     }
 }
 
-void load_configuration(void) {
+extern "C" int load_configuration(void) {
     // Try to load configs
     if (NVM_init() ||
         ConfigFormat::safe_load_config(
@@ -71,6 +71,7 @@ void load_configuration(void) {
     } else {
         user_config_loaded_ = true;
     }
+    return user_config_loaded_;
 }
 
 void erase_configuration(void) {
@@ -117,7 +118,6 @@ void vApplicationIdleHook(void) {
 
 int odrive_main(void) {
     // Load persistent configuration (or defaults)
-    load_configuration();
 
 #if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 3
     if (board_config.enable_i2c_instead_of_can) {

--- a/Firmware/MotorControl/sensorless_estimator.hpp
+++ b/Firmware/MotorControl/sensorless_estimator.hpp
@@ -14,7 +14,7 @@ public:
         float pm_flux_linkage = 1.58e-3f; // [V / (rad/s)]  { 5.51328895422 / (<pole pairs> * <rpm/v>) }
     };
 
-    SensorlessEstimator(Config_t& config);
+    explicit SensorlessEstimator(Config_t& config);
 
     bool update();
 

--- a/Firmware/MotorControl/trapTraj.hpp
+++ b/Firmware/MotorControl/trapTraj.hpp
@@ -9,13 +9,14 @@ public:
         float decel_limit = 5000.0f; // [count/s^2]
         float A_per_css = 0.0f;      // [A/(count/s^2)]
     };
+    
     struct Step_t {
         float Y;
         float Yd;
         float Ydd;
     };
 
-    TrapezoidalTrajectory(Config_t& config);
+    explicit TrapezoidalTrajectory(Config_t& config);
     bool planTrapezoidal(float Xf, float Xi, float Vi,
                          float Vmax, float Amax, float Dmax);
     Step_t eval(float t);

--- a/Firmware/Tupfile.lua
+++ b/Firmware/Tupfile.lua
@@ -92,7 +92,12 @@ FLAGS += '-mfloat-abi=hard'
 FLAGS += { '-Wall', '-Wdouble-promotion', '-Wfloat-conversion', '-fdata-sections', '-ffunction-sections'}
 
 -- debug build
-FLAGS += '-g -gdwarf-2'
+if tup.getconfig("DEBUG") == "true" then
+    FLAGS += '-g -gdwarf-2'
+    OPT += '-Og'
+else
+    OPT += '-O2'
+end
 
 
 -- linker flags
@@ -104,7 +109,8 @@ LDFLAGS += '-Wl,--undefined=uxTopUsedPriority'
 
 
 -- common flags for ASM, C and C++
-OPT += '-Og'
+-- OPT += '-Og'
+-- OPT += '-O2'
 -- OPT += '-O0'
 OPT += '-ffast-math -fno-finite-math-only'
 tup.append_table(FLAGS, OPT)

--- a/Firmware/build.lua
+++ b/Firmware/build.lua
@@ -162,7 +162,7 @@ function build(args)
 
         outputs.includes = {}
         for _,inc in pairs(args.includes) do
-            table.insert(outputs.includes, tup.nodevariable(inc))
+            table.insert(outputs.includes, inc)
         end
         if args.name != nil then
             all_packages[args.name] = outputs

--- a/Firmware/build.lua
+++ b/Firmware/build.lua
@@ -56,7 +56,7 @@ function GCCToolchain(prefix, builddir, compiler_flags, linker_flags)
         compiler_flags += '-fstack-usage'
     end
 
-    gcc_generic_compiler = function(compiler, compiler_flags, gen_su_file, src, flags, includes, outputs)
+    local gcc_generic_compiler = function(compiler, compiler_flags, gen_su_file, src, flags, includes, outputs)
         -- convert include list to flags
         inc_flags = {}
         for _,inc in pairs(includes) do

--- a/Firmware/build.lua
+++ b/Firmware/build.lua
@@ -63,7 +63,7 @@ function GCCToolchain(prefix, builddir, compiler_flags, linker_flags)
             inc_flags += "-I"..inc
         end
         -- todo: vary build directory
-        obj_file = builddir.."/"..src:gsub("/","_")..".o"
+        obj_file = builddir.."/obj/"..src:gsub("/","_")..".o"
         outputs.object_files += obj_file
         if gen_su_file then
             su_file = builddir.."/"..src:gsub("/","_")..".su"

--- a/Firmware/fibre/cpp/include/fibre/protocol.hpp
+++ b/Firmware/fibre/cpp/include/fibre/protocol.hpp
@@ -106,10 +106,7 @@ inline size_t write_le<float>(float value, uint8_t* buffer) {
 
 template<typename T>
 inline size_t read_le(T* value, const uint8_t* buffer){
-    *value = static_cast<T>(buffer[0]);
-    for(size_t i = 1; i < sizeof(*value); ++i){
-        *value |= static_cast<T>(buffer[i]) << i*8;
-    }
+    std::memcpy(value, buffer, sizeof(*value));
     return sizeof(*value);
 }
 

--- a/Firmware/fibre/cpp/include/fibre/protocol.hpp
+++ b/Firmware/fibre/cpp/include/fibre/protocol.hpp
@@ -82,12 +82,11 @@ typedef struct {
     uint16_t endpoint_id;
 } endpoint_ref_t;
 
+#include <cstring>
 
 template<typename T, typename = typename std::enable_if_t<!std::is_const<T>::value>>
 inline size_t write_le(T value, uint8_t* buffer){
-    for(size_t i = 0; i < sizeof(value); ++i){
-        buffer[i] = (value >> 8*i) & 0xff;
-    }
+    std::memcpy(&buffer[0], &value, sizeof(value));
     return sizeof(value);
 }
 
@@ -118,6 +117,7 @@ template<>
 inline size_t read_le<float>(float* value, const uint8_t* buffer) {
     static_assert(CHAR_BIT * sizeof(float) == 32, "32 bit floating point expected");
     static_assert(std::numeric_limits<float>::is_iec559, "IEEE 754 floating point expected");
+
     return read_le(reinterpret_cast<uint32_t*>(value), buffer);
 }
 

--- a/Firmware/fibre/cpp/include/fibre/protocol.hpp
+++ b/Firmware/fibre/cpp/include/fibre/protocol.hpp
@@ -86,6 +86,7 @@ typedef struct {
 
 template<typename T, typename = typename std::enable_if_t<!std::is_const<T>::value>>
 inline size_t write_le(T value, uint8_t* buffer){
+    //TODO: add static_assert that this is still a little endian machine
     std::memcpy(&buffer[0], &value, sizeof(value));
     return sizeof(value);
 }
@@ -106,6 +107,7 @@ inline size_t write_le<float>(float value, uint8_t* buffer) {
 
 template<typename T>
 inline size_t read_le(T* value, const uint8_t* buffer){
+    // TODO: add static_assert that this is still a little endian machine
     std::memcpy(value, buffer, sizeof(*value));
     return sizeof(*value);
 }

--- a/Firmware/fibre/cpp/include/fibre/protocol.hpp
+++ b/Firmware/fibre/cpp/include/fibre/protocol.hpp
@@ -84,59 +84,17 @@ typedef struct {
 
 
 template<typename T, typename = typename std::enable_if_t<!std::is_const<T>::value>>
-inline size_t write_le(T value, uint8_t* buffer);
+inline size_t write_le(T value, uint8_t* buffer){
+    for(size_t i = 0; i < sizeof(value); ++i){
+        buffer[i] = (value >> 8*i) & 0xff;
+    }
+    return sizeof(value);
+}
 
 template<typename T>
-inline size_t read_le(T* value, const uint8_t* buffer);
-
-template<>
-inline size_t write_le<bool>(bool value, uint8_t* buffer) {
-    buffer[0] = value ? 1 : 0;
-    return 1;
-}
-
-template<>
-inline size_t write_le<uint8_t>(uint8_t value, uint8_t* buffer) {
-    buffer[0] = value;
-    return 1;
-}
-
-template<>
-inline size_t write_le<uint16_t>(uint16_t value, uint8_t* buffer) {
-    buffer[0] = (value >> 0) & 0xff;
-    buffer[1] = (value >> 8) & 0xff;
-    return 2;
-}
-
-template<>
-inline size_t write_le<uint32_t>(uint32_t value, uint8_t* buffer) {
-    buffer[0] = (value >> 0) & 0xff;
-    buffer[1] = (value >> 8) & 0xff;
-    buffer[2] = (value >> 16) & 0xff;
-    buffer[3] = (value >> 24) & 0xff;
-    return 4;
-}
-
-template<>
-inline size_t write_le<int32_t>(int32_t value, uint8_t* buffer) {
-    buffer[0] = (value >> 0) & 0xff;
-    buffer[1] = (value >> 8) & 0xff;
-    buffer[2] = (value >> 16) & 0xff;
-    buffer[3] = (value >> 24) & 0xff;
-    return 4;
-}
-
-template<>
-inline size_t write_le<uint64_t>(uint64_t value, uint8_t* buffer) {
-    buffer[0] = (value >> 0) & 0xff;
-    buffer[1] = (value >> 8) & 0xff;
-    buffer[2] = (value >> 16) & 0xff;
-    buffer[3] = (value >> 24) & 0xff;
-    buffer[4] = (value >> 32) & 0xff;
-    buffer[5] = (value >> 40) & 0xff;
-    buffer[6] = (value >> 48) & 0xff;
-    buffer[7] = (value >> 56) & 0xff;
-    return 8;
+typename std::enable_if_t<std::is_const<T>::value, size_t>
+write_le(T value, uint8_t* buffer) {
+    return write_le<std::remove_const_t<T>>(value, buffer);
 }
 
 template<>
@@ -148,59 +106,12 @@ inline size_t write_le<float>(float value, uint8_t* buffer) {
 }
 
 template<typename T>
-typename std::enable_if_t<std::is_const<T>::value, size_t>
-write_le(T value, uint8_t* buffer) {
-    return write_le<std::remove_const_t<T>>(value, buffer);
-}
-
-template<>
-inline size_t read_le<bool>(bool* value, const uint8_t* buffer) {
-    *value = buffer[0];
-    return 1;
-}
-
-template<>
-inline size_t read_le<uint8_t>(uint8_t* value, const uint8_t* buffer) {
-    *value = buffer[0];
-    return 1;
-}
-
-template<>
-inline size_t read_le<uint16_t>(uint16_t* value, const uint8_t* buffer) {
-    *value = (static_cast<uint16_t>(buffer[0]) << 0) |
-             (static_cast<uint16_t>(buffer[1]) << 8);
-    return 2;
-}
-
-template<>
-inline size_t read_le<int32_t>(int32_t* value, const uint8_t* buffer) {
-    *value = (static_cast<int32_t>(buffer[0]) << 0) |
-             (static_cast<int32_t>(buffer[1]) << 8) |
-             (static_cast<int32_t>(buffer[2]) << 16) |
-             (static_cast<int32_t>(buffer[3]) << 24);
-    return 4;
-}
-
-template<>
-inline size_t read_le<uint32_t>(uint32_t* value, const uint8_t* buffer) {
-    *value = (static_cast<uint32_t>(buffer[0]) << 0) |
-             (static_cast<uint32_t>(buffer[1]) << 8) |
-             (static_cast<uint32_t>(buffer[2]) << 16) |
-             (static_cast<uint32_t>(buffer[3]) << 24);
-    return 4;
-}
-
-template<>
-inline size_t read_le<uint64_t>(uint64_t* value, const uint8_t* buffer) {
-    *value = (static_cast<uint64_t>(buffer[0]) << 0) |
-             (static_cast<uint64_t>(buffer[1]) << 8) |
-             (static_cast<uint64_t>(buffer[2]) << 16) |
-             (static_cast<uint64_t>(buffer[3]) << 24) |
-             (static_cast<uint64_t>(buffer[4]) << 32) |
-             (static_cast<uint64_t>(buffer[5]) << 40) |
-             (static_cast<uint64_t>(buffer[6]) << 48) |
-             (static_cast<uint64_t>(buffer[7]) << 56);
-    return 8;
+inline size_t read_le(T* value, const uint8_t* buffer){
+    *value = static_cast<T>(buffer[0]);
+    for(size_t i = 1; i < sizeof(*value); ++i){
+        *value |= static_cast<T>(buffer[i]) << i*8;
+    }
+    return sizeof(*value);
 }
 
 template<>
@@ -497,6 +408,14 @@ inline constexpr const char* get_default_json_modifier<const float>() {
 template<>
 inline constexpr const char* get_default_json_modifier<float>() {
     return "\"type\":\"float\",\"access\":\"rw\"";
+}
+template<>
+inline constexpr const char* get_default_json_modifier<const int64_t>() {
+    return "\"type\":\"int64\",\"access\":\"r\"";
+}
+template<>
+inline constexpr const char* get_default_json_modifier<int64_t>() {
+    return "\"type\":\"int64\",\"access\":\"rw\"";
 }
 template<>
 inline constexpr const char* get_default_json_modifier<const uint64_t>() {

--- a/Firmware/fibre/tupfiles/build.lua
+++ b/Firmware/fibre/tupfiles/build.lua
@@ -5,7 +5,7 @@ function GCCToolchain(prefix, builddir, compiler_flags, linker_flags)
     -- add some default compiler flags
     compiler_flags += '-fstack-usage'
 
-    gcc_generic_compiler = function(compiler, compiler_flags, gen_su_file, src, flags, includes, outputs)
+    local gcc_generic_compiler = function(compiler, compiler_flags, gen_su_file, src, flags, includes, outputs)
         -- resolve source path
         src = tostring(src)
 

--- a/Firmware/tup.config.default
+++ b/Firmware/tup.config.default
@@ -3,6 +3,7 @@
 #CONFIG_BOARD_VERSION=v3.5-24V
 CONFIG_USB_PROTOCOL=native
 CONFIG_UART_PROTOCOL=ascii
+CONFIG_DEBUG=false
 
 # Uncomment this to error on compilation warnings
 #CONFIG_STRICT=true

--- a/ODrive_Workspace.code-workspace
+++ b/ODrive_Workspace.code-workspace
@@ -18,6 +18,8 @@
 			"${workspaceRoot}/communication",
 			"${workspaceRoot}/MotorControl",
 		],
+		"c-cpp-flylint.cppcheck.platform": "avr8",
+		"c-cpp-flylint.cppcheck.standard": ["c99","c++14"],
 
 		"files.associations": {
 			"memory": "cpp",


### PR DESCRIPTION
Fibre:
* Cleanup fibre protocol templates so they're actually generic
* Support int64_t in fibre protocol
* Use `memcpy` in fibre buffer read/write to avoid undefined behavior

ODrive:
* Move load_configuration() so it executes prior to thread creation
* Declare constructors explicit to avoid accidental implicit conversion

Toolchain:
* Object files generated during build go to build/obj to avoid clutter
* Fix an issue in tup that was preventing it from using include paths outside of the workspace
* Add `CONFIG_DEBUG` flag in tup.config
* Compile with `-O2` by default, or `-Og -g -gdwarf-2` when building DEBUG
* Intellisense fixes for Windows
* Tweaks to CppCheck config