### PR TITLE
Included description of * `ERROR_OVERSPEED = 0x01`

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -95,6 +95,11 @@ Confirm that your encoder is plugged into the right pins on the odrive board.
 
 Check that your encoder is a model that has an index pulse. If your encoder does not have a wire connected to pin Z on your odrive then it does not output an index pulse.
 
+## Common Controller Errors
+
+* `ERROR_OVERSPEED = 0x01`
+
+Try increasing `<axis>.controller.config.vel_limit`. The default `vel_limit` of 20,000 encoder counts per second gives a motor speed of only ~146 RPM with the common CUI-AMT102 8192 count per rotation encoder. Note: Even if you do not commanded your motor to exceed `vel_limit` sudden changes in the load placed on a motor may cause this speed to be temporarily exceeded, resulting in this error. Therefore, provided it is safe to do so, setting `vel_limit` 1.5x above your maximum intended speed may help avoid this error.
 
 ## USB Connectivity Issues
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,7 @@ Table of Contents:
 - [Common Axis Errors](#common-axis-errors)
 - [Common Motor Errors](#common-motor-errors)
 - [Common Encoder Errors](#common-encoder-errors)
+- [Common Controller Errors](#common-controller-errors)
 - [USB Connectivity Issues](#usb-connectivity-issues)
 - [Firmware Issues](#firmware-issues)
 - [Other issues that may not produce an error code](#other-issues-that-may-not-produce-an-error-code)
@@ -100,6 +101,8 @@ Check that your encoder is a model that has an index pulse. If your encoder does
 * `ERROR_OVERSPEED = 0x01`
 
 Try increasing `<axis>.controller.config.vel_limit`. The default `vel_limit` of 20,000 encoder counts per second gives a motor speed of only ~146 RPM with the common CUI-AMT102 8192 count per rotation encoder. Note: Even if you do not commanded your motor to exceed `vel_limit` sudden changes in the load placed on a motor may cause this speed to be temporarily exceeded, resulting in this error. Therefore, provided it is safe to do so, setting `vel_limit` 1.5x above your maximum intended speed may help avoid this error.
+
+You can also try increasing `<axis>.controller.config.vel_limit_tolerance`. The default value of 1.2 means it will only allow a 20% violation of the speed limit.
 
 ## USB Connectivity Issues
 


### PR DESCRIPTION
I have been encountering this error when running two motors back to back and this is my current understanding of why it is caused.

Just a side note: Perhaps it may be useful for this error to only trigger if `vel_limit` is exceeded for some meaningful length of time. e.g. > 250 ms.