### PR TITLE
Update developer-guide.md CONFIG_USB_PROTOCOL on macOS

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -97,8 +97,8 @@ To customize the compile time parameters, copy or rename the file `Firmware/tup.
 __CONFIG_BOARD_VERSION__: The board version you're using. Can be `v3.1`, `v3.2`, `v3.3`, `v3.4-24V`, `v3.4-48V`, `v3.5-24V`, `v3.5-48V`, etc. Check for a label on the upper side of the ODrive to find out which version you have. Some ODrive versions don't specify the voltage: in that case you can read the value of the main capacitors: 120uF are 48V ODrives, 470uF are 24V ODrives.
 
 __CONFIG_USB_PROTOCOL__: Defines which protocol the ODrive should use on the USB interface.
- * `native`: The native ODrive protocol. Use this if you want to use the python tools in this repo.
- * `native-stream`: Like the native ODrive protocol, but the ODrive will treat the USB connection exactly as if it was a UART connection. __Use this if you're on macOS__. This is necessary because macOS doesn't grant our python tools sufficient low-level access to treat the device as the USB device that it is.
+ * `native`: The native ODrive protocol. Use this if you want to use the python tools in this repo. Can maybe work with macOS.
+ * `native-stream`: Like the native ODrive protocol, but the ODrive will treat the USB connection exactly as if it was a UART connection. __ Maybe need to use this if you're on macOS__. This is necessary because macOS doesn't grant our python tools sufficient low-level access to treat the device as the USB device that it is.
  * `none`: Disable USB. The device will still show up when plugged in but it will ignore any commands.
  
  **Note**: There is a second USB interface that is always a serial port.


### PR DESCRIPTION
CONFIG_USB_PROTOCOL native works for me on mac, but native-stream did not.