### PR TITLE
Fix NVM bug that prevented from saving configuration three times in a row

### DIFF
--- a/Firmware/MotorControl/nvm.c
+++ b/Firmware/MotorControl/nvm.c
@@ -362,10 +362,12 @@ int NVM_commit(void) {
     read_sector_ = 1 - read_sector_;
 
     // invalidate the other sector
-    if (read_sector->index < read_sector->n_data)
+    if (read_sector->index < read_sector->n_data) {
         status = set_allocation_state(read_sector, read_sector->index, 1, INVALID);
-    else
+        read_sector->index += 1;
+    } else {
         status = erase(read_sector);
+    }
 
     return status;
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -222,8 +222,6 @@ This is 4x the Pulse Per Revolution (PPR) value. Usually this is indicated in th
 You can save all `.config` parameters to persistent memory so the ODrive remembers them between power cycles. 
 * `odrv0.save_configuration()` <kbd>Enter</kbd>. 
 
-Due to a [known issue](https://github.com/madcowswe/ODrive/issues/183) it is strongly recommended that you reboot following every save of your configuration using `odrv0.reboot()`.
-
 
 ## Position control of M0
 Let's get motor 0 up and running. The procedure for motor 1 is exactly the same, so feel free to substitute `axis0` wherever it says `axis0`.


### PR DESCRIPTION
Addresses #183 

Before (in odrivetool):
```
> odrv0.config.brake_resistance
2.0

> odrv0.config.brake_resistance = 3; odrv0.save_configuration(); odrv0.config.brake_resistance = 4; odrv0.save_configuration(); odrv0.config.brake_resistance = 5; odrv0.save_configuration(); odrv0.reboot();
[wait for reboot]
> odrv0.config.brake_resistance
3.0 # expected output: 5.0
```

After:
```
> odrv0.config.brake_resistance
2.0

> odrv0.config.brake_resistance = 3; odrv0.save_configuration(); odrv0.config.brake_resistance = 4; odrv0.save_configuration(); odrv0.config.brake_resistance = 5; odrv0.save_configuration(); odrv0.reboot();
[wait for reboot]
> odrv0.config.brake_resistance
5.0

> odrv0.config.brake_resistance = 6; odrv0.save_configuration(); odrv0.config.brake_resistance = 7; odrv0.save_configuration(); odrv0.reboot();
[wait for reboot]
> odrv0.config.brake_resistance
7.0

> odrv0.config.brake_resistance = 8; odrv0.save_configuration(); odrv0.reboot();
[wait for reboot]
> odrv0.config.brake_resistance
8.0
```