### PR TITLE
fix bad use of memcpy

### DIFF
--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -438,6 +438,6 @@ void Axis::run_state_machine_loop() {
         if (!status)
             current_state_ = AXIS_STATE_IDLE;
         else
-            memcpy(task_chain_, task_chain_ + 1, sizeof(task_chain_) - sizeof(task_chain_[0]));
+            memmove(task_chain_, task_chain_ + 1, sizeof(task_chain_) - sizeof(task_chain_[0]));
     }
 }


### PR DESCRIPTION
memcpy is not guaranteed to work with overlapped memory areas, however memmove is.
Apart from the semantic difference this fixes a compiler warning and possibly previously unexplained occurrences of `ERROR_INVALID_STATE`.