### PR TITLE
support "unsigned int" type in native protocol (aka Fibre)

### DIFF
--- a/Firmware/fibre/cpp/include/fibre/protocol.hpp
+++ b/Firmware/fibre/cpp/include/fibre/protocol.hpp
@@ -398,7 +398,7 @@ bool default_readwrite_endpoint_handler(endpoint_ref_t* value, const uint8_t* in
 }
 
 template<typename T>
-static inline const char* get_default_json_modifier();
+static constexpr inline const char* get_default_json_modifier();
 
 template<>
 inline constexpr const char* get_default_json_modifier<const float>() {
@@ -439,6 +439,14 @@ inline constexpr const char* get_default_json_modifier<const uint32_t>() {
 template<>
 inline constexpr const char* get_default_json_modifier<uint32_t>() {
     return "\"type\":\"uint32\",\"access\":\"rw\"";
+}
+template<>
+inline constexpr const char* get_default_json_modifier<const unsigned int>() {
+    return "\"type\":\"uint32\",\"access\":\"r\""; // TODO: automatically detect size
+}
+template<>
+inline constexpr const char* get_default_json_modifier<unsigned int>() {
+    return "\"type\":\"uint32\",\"access\":\"rw\""; // TODO: automatically detect size
 }
 template<>
 inline constexpr const char* get_default_json_modifier<const uint16_t>() {
@@ -536,6 +544,11 @@ template<> struct format_traits_t<int32_t> { using type = void;
 template<> struct format_traits_t<uint32_t> { using type = void;
     static constexpr const char * fmt = "%lu";
     static constexpr const char * fmtp = "%lu";
+};
+// TODO: change all overloads to fundamental int type space
+template<> struct format_traits_t<unsigned int> { using type = void;
+    static constexpr const char * fmt = "%ud";
+    static constexpr const char * fmtp = "%ud";
 };
 template<> struct format_traits_t<int16_t> { using type = void;
     static constexpr const char * fmt = "%hd";


### PR DESCRIPTION
This fixes a compile error when using enums with large numerical values. The int type of such enums is unsigned int, which was previously not supported.