### PR TITLE
Dynamically reconfigure UART to GPIO 3 and 4

### DIFF
--- a/Firmware/Board/v3/Inc/stm32f4xx_it.h
+++ b/Firmware/Board/v3/Inc/stm32f4xx_it.h
@@ -63,6 +63,7 @@ void CAN1_TX_IRQHandler(void);
 void CAN1_RX0_IRQHandler(void);
 void CAN1_RX1_IRQHandler(void);
 void CAN1_SCE_IRQHandler(void);
+void USART2_IRQHandler(void);
 void TIM8_TRG_COM_TIM14_IRQHandler(void);
 void TIM5_IRQHandler(void);
 void SPI3_IRQHandler(void);

--- a/Firmware/Board/v3/Inc/usart.h
+++ b/Firmware/Board/v3/Inc/usart.h
@@ -62,6 +62,7 @@
 /* USER CODE END Includes */
 
 extern UART_HandleTypeDef huart4;
+extern UART_HandleTypeDef huart2;
 
 /* USER CODE BEGIN Private defines */
 
@@ -70,6 +71,7 @@ extern UART_HandleTypeDef huart4;
 extern void _Error_Handler(char *, int);
 
 void MX_UART4_Init(void);
+void MX_USART2_UART_Init(void);
 
 /* USER CODE BEGIN Prototypes */
 

--- a/Firmware/Board/v3/Src/main.c
+++ b/Firmware/Board/v3/Src/main.c
@@ -189,7 +189,8 @@ int main(void)
   MX_ADC3_Init();
   MX_TIM2_Init();
   MX_UART4_Init();
-  MX_TIM5_Init();
+  // MX_TIM5_Init(); // TIM5 or USART2 decided in main.cpp instead
+  // MX_USART2_UART_Init();
   MX_TIM13_Init();
   /* USER CODE BEGIN 2 */
 

--- a/Firmware/Board/v3/Src/stm32f4xx_it.c
+++ b/Firmware/Board/v3/Src/stm32f4xx_it.c
@@ -71,6 +71,7 @@ extern TIM_HandleTypeDef htim8;
 extern DMA_HandleTypeDef hdma_uart4_rx;
 extern DMA_HandleTypeDef hdma_uart4_tx;
 extern UART_HandleTypeDef huart4;
+extern UART_HandleTypeDef huart2;
 
 extern TIM_HandleTypeDef htim14;
 
@@ -345,6 +346,20 @@ void CAN1_SCE_IRQHandler(void)
   /* USER CODE BEGIN CAN1_SCE_IRQn 1 */
 
   /* USER CODE END CAN1_SCE_IRQn 1 */
+}
+
+/**
+  * @brief This function handles USART2 global interrupt.
+  */
+void USART2_IRQHandler(void)
+{
+  /* USER CODE BEGIN USART2_IRQn 0 */
+
+  /* USER CODE END USART2_IRQn 0 */
+  HAL_UART_IRQHandler(&huart2);
+  /* USER CODE BEGIN USART2_IRQn 1 */
+
+  /* USER CODE END USART2_IRQn 1 */
 }
 
 /**

--- a/Firmware/Board/v3/Src/usart.c
+++ b/Firmware/Board/v3/Src/usart.c
@@ -58,6 +58,7 @@
 /* USER CODE END 0 */
 
 UART_HandleTypeDef huart4;
+UART_HandleTypeDef huart2;
 DMA_HandleTypeDef hdma_uart4_rx;
 DMA_HandleTypeDef hdma_uart4_tx;
 
@@ -76,6 +77,25 @@ void MX_UART4_Init(void)
   if (HAL_UART_Init(&huart4) != HAL_OK)
   {
     _Error_Handler(__FILE__, __LINE__);
+  }
+
+}
+/* USART2 init function */
+
+void MX_USART2_UART_Init(void)
+{
+
+  huart2.Instance = USART2;
+  huart2.Init.BaudRate = 115200;
+  huart2.Init.WordLength = UART_WORDLENGTH_8B;
+  huart2.Init.StopBits = UART_STOPBITS_1;
+  huart2.Init.Parity = UART_PARITY_NONE;
+  huart2.Init.Mode = UART_MODE_TX_RX;
+  huart2.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+  huart2.Init.OverSampling = UART_OVERSAMPLING_16;
+  if (HAL_UART_Init(&huart2) != HAL_OK)
+  {
+    Error_Handler();
   }
 
 }
@@ -154,6 +174,33 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
 
   /* USER CODE END UART4_MspInit 1 */
   }
+  else if(uartHandle->Instance==USART2)
+  {
+  /* USER CODE BEGIN USART2_MspInit 0 */
+
+  /* USER CODE END USART2_MspInit 0 */
+    /* USART2 clock enable */
+    __HAL_RCC_USART2_CLK_ENABLE();
+  
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    /**USART2 GPIO Configuration    
+    PA2     ------> USART2_TX
+    PA3     ------> USART2_RX 
+    */
+    GPIO_InitStruct.Pin = GPIO_3_Pin|GPIO_4_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Alternate = GPIO_AF7_USART2;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    /* USART2 interrupt Init */
+    HAL_NVIC_SetPriority(USART2_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(USART2_IRQn);
+  /* USER CODE BEGIN USART2_MspInit 1 */
+
+  /* USER CODE END USART2_MspInit 1 */
+  }
 }
 
 void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
@@ -182,6 +229,26 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
   /* USER CODE BEGIN UART4_MspDeInit 1 */
 
   /* USER CODE END UART4_MspDeInit 1 */
+  }
+  else if(uartHandle->Instance==USART2)
+  {
+  /* USER CODE BEGIN USART2_MspDeInit 0 */
+
+  /* USER CODE END USART2_MspDeInit 0 */
+    /* Peripheral clock disable */
+    __HAL_RCC_USART2_CLK_DISABLE();
+  
+    /**USART2 GPIO Configuration    
+    PA2     ------> USART2_TX
+    PA3     ------> USART2_RX 
+    */
+    HAL_GPIO_DeInit(GPIOA, GPIO_3_Pin|GPIO_4_Pin);
+
+    /* USART2 interrupt Deinit */
+    HAL_NVIC_DisableIRQ(USART2_IRQn);
+  /* USER CODE BEGIN USART2_MspDeInit 1 */
+
+  /* USER CODE END USART2_MspDeInit 1 */
   }
 } 
 

--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -172,16 +172,28 @@ int odrive_main(void) {
         axes[i] = new Axis(i, hw_configs[i].axis_config, axis_configs[i],
                 *encoder, *sensorless_estimator, *controller, *motor, *trap);
     }
-    
+
     // Start ADC for temperature measurements and user measurements
     start_general_purpose_adc();
 
-    // TODO: make dynamically reconfigurable
 #if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 3
     if (board_config.enable_uart) {
-        SetGPIO12toUART();
+#if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 5
+        if (board_config.move_uart_to_gpio_3_and_4)
+        {
+            MX_USART2_UART_Init();
+        }
+        else
+#endif
+            SetGPIO12toUART();
     }
 #endif
+
+#if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 5
+    if (not board_config.enable_uart or not board_config.move_uart_to_gpio_3_and_4)
+#endif
+        MX_TIM5_Init();
+
     //osDelay(100);
     // Init communications (this requires the axis objects to be constructed)
     init_communication();

--- a/Firmware/MotorControl/odrive_main.h
+++ b/Firmware/MotorControl/odrive_main.h
@@ -19,6 +19,7 @@ extern "C" {
 #include <i2c.h>
 #define ARM_MATH_CM4 // TODO: might change in future board versions
 #include <arm_math.h>
+#include <usart.h>
 
 // OS includes
 #include <cmsis_os.h>
@@ -69,6 +70,9 @@ struct PWMMapping_t {
 // @brief general user configurable board configuration
 struct BoardConfig_t {
     bool enable_uart = true;
+#if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 5
+    bool move_uart_to_gpio_3_and_4 = false;
+#endif
     bool enable_i2c_instead_of_can = false;
     bool enable_ascii_protocol_on_usb = true;
 #if HW_VERSION_MAJOR == 3 && HW_VERSION_MINOR >= 5 && HW_VERSION_VOLTAGE >= 48

--- a/Firmware/communication/interface_uart.h
+++ b/Firmware/communication/interface_uart.h
@@ -3,16 +3,17 @@
 
 #ifdef __cplusplus
 #include "fibre/protocol.hpp"
-extern StreamSink* uart4_stream_output_ptr;
+extern StreamSink* uart_stream_output_ptr;
 
 extern "C" {
 #endif
 
 #include <cmsis_os.h>
+#include <usart.h>
 
 extern osThreadId uart_thread;
 
-void start_uart_server(void);
+void start_uart_server(UART_HandleTypeDef*);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### WIP: Only tested to compile, not tested on hardware.

This PR tries to make it possible for a user to say
```
odrv0.config.enable_uart = True
odrv0.config.move_uart_to_gpio_3_and_4 = True
odrv0.save_configuration()
odrv0.reboot()
```
After the reboot, the ODrive should talk UART on GPIO pins 3 and 4 instead of the default 1 and 2.

The intention is to enable this on v3.5 or later only, since earlier versions use GPIO 3 and 4 for step/dir.