### PR TITLE
Add links to odrivetool banner

### DIFF
--- a/tools/odrive/shell.py
+++ b/tools/odrive/shell.py
@@ -9,6 +9,13 @@ from odrive.utils import start_liveplotter, dump_errors
 #from odrive.enums import * # pylint: disable=W0614
 
 def print_banner():
+    print("Website: https://odriverobotics.com/")
+    print("Docs: https://docs.odriverobotics.com/")
+    print("Forums: https://discourse.odriverobotics.com/")
+    print("Discord: https://discord.gg/k3ZZ3mS")
+    print("Github: https://github.com/madcowswe/ODrive/")
+
+    print()
     print('Please connect your ODrive.')
     print('You can also type help() or quit().')
 


### PR DESCRIPTION
Added the following text to the odrivetool banner:

Website: https://odriverobotics.com/
Docs: https://docs.odriverobotics.com/
Forums: https://discourse.odriverobotics.com/
Discord: https://discord.gg/k3ZZ3mS
Github: https://github.com/madcowswe/ODrive/