### PR TITLE
Improved UART handler task

### DIFF
--- a/Firmware/communication/CircularBuffer.hpp
+++ b/Firmware/communication/CircularBuffer.hpp
@@ -1,0 +1,327 @@
+/*******************************************************************************
+* File          : circularBuffer.hpp
+*
+* Description   : Implementation file for circular buffers
+*
+* Project       :
+*
+* Author        : S.Gilbert
+*
+* Created on    : 09 Dec 2019
+*
+*
+*******************************************************************************/
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef CIRCULAR_BUFFER_H
+#define CIRCULAR_BUFFER_H
+
+/*******************************************************************************
+INCLUDES
+*******************************************************************************/
+
+#include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/*******************************************************************************
+NAMESPACE
+*******************************************************************************/
+
+/*******************************************************************************
+DEFINITIONS
+*******************************************************************************/
+
+typedef enum
+{
+	CB_OK = 0,
+	CB_FAIL,
+	CB_SIZE_ERROR,
+	CB_POINTER_ERROR
+}CB_Status_t;
+
+/*******************************************************************************
+TYPES
+*******************************************************************************/
+
+/*******************************************************************************
+GLOBAL VARIABLES
+*******************************************************************************/
+
+/*******************************************************************************
+FUNCTION PROTOTYPES
+*******************************************************************************/
+
+template <class dataType_t>
+class CCBBuffer
+{
+    typedef struct
+    {
+        size_t numElements;                                                     /* maximum number of elements */
+        int32_t start;                                                          /* index of oldest element */
+        int32_t end;                                                            /* index at which to write new element */
+    }CBTracker_t;
+
+    typedef struct
+    {
+        CBTracker_t tracker;                                                    /* buffer size and start/end counters */
+        dataType_t * pArray;                                                    /* pointer to array of elements. to be set on buffer init */
+    }circularBuffer_t;
+public:
+
+public:
+
+    CCBBuffer(dataType_t * pArray = nullptr, const size_t size = 0, const bool useMutex = false, const bool overwriteOldData = false);
+    ~CCBBuffer() = default;
+    bool isFull();
+    bool isEmpty();
+    size_t remainingSpace();
+    size_t remainingSpaceLinear();
+    size_t usedSpace();
+    size_t usedSpaceLinear();
+    bool flushBuffer();
+    int32_t write(const dataType_t * const elem, size_t length);
+    int32_t read(dataType_t * elem, size_t length);
+    bool readNewest(dataType_t * pData);
+
+private:
+    circularBuffer_t m_cb;
+    bool m_useMutex;
+    bool m_overwriteOldData;
+private:
+    /**\brief   Calculates whether a value in the argument is to the power of 2
+     *          by taking the bit pattern of x and logically ANDing it with the bit
+     *          pattern of (x-1). If the result is 0 then the number is = ^2
+     *
+     * \param   x   - value to test
+     *
+     * \return  true if value is non-zero and to the power of 2, else returns false
+     */
+    static bool isPowerOfTwo(size_t x)
+    {
+        return (x != 0u) && ((x & (x - 1u)) == 0u);
+    }
+}; /* CCBBuffer */
+
+/*******************************************************************************
+INLINE FUNCTIONS
+*******************************************************************************/
+
+/**\brief   Constructor
+ *
+ * \param   pArray              - pointer to external memory
+ * \param   numElements         - number of dataType_t's in ring buffer to be created, must be a value ^2 if doing bulk writes
+ * \param   useMutex            - enables or disables mutex locking. Defaults to false
+ * \param   overwriteOldData    - enables discarding of old data. Defaults to false
+ *
+ * \return  None
+ */
+template <class dataType_t>
+CCBBuffer<dataType_t>::CCBBuffer(dataType_t * pArray, const size_t numElements, const bool useMutex, const bool overwriteOldData)
+    : m_cb {{numElements, 0, 0}, pArray}
+    , m_overwriteOldData(overwriteOldData)
+{
+//        assert(this->isPowerOfTwo(size), "The size must be of ^2 otherwise overflow condition of start/end tracker values will corrupt data in buffer ");
+    (void)flushBuffer();
+}
+
+/**\brief   Checks if the ring buffer is full
+ *
+ * \param   None
+ *
+ * \return  TRUE for full FALSE for not
+ */
+template <class dataType_t>
+bool CCBBuffer<dataType_t>::isFull()
+{
+    return (((m_cb.tracker.end + 1) % (int32_t)m_cb.tracker.numElements) == m_cb.tracker.start);
+}
+
+/**\brief   Checks if the ring buffer is empty
+ *
+ * \param   None
+ *
+ * \return  FALSE for non-empty TRUE for not
+ */
+template <class dataType_t>
+bool CCBBuffer<dataType_t>::isEmpty()
+{
+    return (m_cb.tracker.end == m_cb.tracker.start);
+}
+
+/**\brief   Checks available space in the buffer
+ *
+ * \param   None
+ *
+ * \return  Unused space in buffer
+ */
+template <class dataType_t>
+size_t CCBBuffer<dataType_t>::remainingSpace()
+{
+    return (m_cb.tracker.numElements - usedSpace());
+}
+
+/**\brief   Checks linearly free space in the buffer from end pointer to array
+ *          start OR string array which ever is reached first (no wrap around)
+ *
+ * \param   None
+ *
+ * \return  Used space in buffer
+ */
+template <class dataType_t>
+size_t CCBBuffer<dataType_t>::remainingSpaceLinear()
+{
+
+/* if end is less than start index then data goes from start pointer to size of
+ * array and start of array to end index. free space exists between end index
+ * and start index. If start is less than end index, then data does from end
+ * index to numElements of array and start of array to start index.
+ */
+    return (size_t)(((m_cb.tracker.end < m_cb.tracker.start) ? m_cb.tracker.end : (int32_t)m_cb.tracker.numElements) - m_cb.tracker.end);
+}
+
+/**\brief   Checks used space in the buffer
+ *
+ * \param   None
+ *
+ * \return  Used space in buffer
+ */
+template <class dataType_t>
+size_t CCBBuffer<dataType_t>::usedSpace()
+{
+    return (size_t)(m_cb.tracker.end + ((m_cb.tracker.end < m_cb.tracker.start) ? (int32_t)m_cb.tracker.numElements : 0) - m_cb.tracker.start);
+}
+
+/**\brief   Checks linearly used space in the buffer from start pointer to array
+ *          end OR string array which ever is reached first (no wrap around)
+ *
+ * \param   None
+ *
+ * \return  Used space in buffer
+ */
+template <class dataType_t>
+size_t CCBBuffer<dataType_t>::usedSpaceLinear()
+{
+    return (size_t)(((m_cb.tracker.end < m_cb.tracker.start) ? (int32_t)m_cb.tracker.numElements : m_cb.tracker.end) - m_cb.tracker.start);
+}
+
+/**\brief   Resets indexers effectively emptying buffer
+ *
+ * \param   None
+ *
+ * \return  TRUE if successful FALSE if fail
+ */
+template <class dataType_t>
+bool CCBBuffer<dataType_t>::flushBuffer()
+{
+    if(m_useMutex)
+    {
+
+    }
+
+    memset(m_cb.pArray, 0, (m_cb.tracker.numElements * sizeof(dataType_t)));
+    m_cb.tracker.start = 0;
+    m_cb.tracker.end   = 0;
+
+    return (m_cb.tracker.start == m_cb.tracker.end);
+}
+
+/**\brief   Writes a number of elements to the buffer, exiting if buffer is full
+ *
+ * \param   pData   - Pointer to data element to be stored
+ * \param   length  - number of entries written to the buffer
+ *
+ * \return  number of entries written
+ */
+template <class dataType_t>
+int32_t CCBBuffer<dataType_t>::write(const dataType_t * const pData, size_t length)
+{
+    int32_t writeCnt = 0;
+    size_t toWrite = 0;
+
+    if(m_useMutex)
+    {
+
+    }
+
+    for (writeCnt = 0; ((writeCnt < (int32_t)length)); writeCnt += toWrite)
+    {
+        size_t linearLength = remainingSpaceLinear();
+        size_t leftToWrite = length - writeCnt;
+        toWrite = (leftToWrite < linearLength) ? leftToWrite : linearLength;
+
+        if(isFull())                                                            /* check if the buffer is full */
+        {
+            if(!m_overwriteOldData)                                             /* if we can't overwrite old data */
+            {
+                break;                                                          /* get out */
+            }
+            else                                                                /* else */
+            {
+                m_cb.tracker.start = ((m_cb.tracker.start + toWrite) % (int32_t)m_cb.tracker.numElements);     /* make space by move the start pointer forward the neccessary elements */
+            }
+        }
+
+        memcpy(&m_cb.pArray[m_cb.tracker.end], &pData[writeCnt], toWrite * sizeof(dataType_t));
+        m_cb.tracker.end = ((m_cb.tracker.end + toWrite) % (int32_t)m_cb.tracker.numElements);
+    }
+
+    return writeCnt;
+}
+
+/**\brief   Reads a length of data starting from oldest element.
+ *
+ * \param   pData   - Pointer to place where data is to be returned
+ * \param   length  - number of entries to be read from the buffer
+ *
+ * \return  number of elements read
+ */
+template <class dataType_t>
+int32_t CCBBuffer<dataType_t>::read(dataType_t * pData, size_t length)
+{
+    int32_t readCnt = 0;
+    size_t toRead = 0;
+
+    if(m_useMutex)
+    {
+
+    }
+
+    for (readCnt = 0; (!isEmpty() && readCnt < (int32_t)length); readCnt =+ toRead)
+    {
+        size_t linearLength = usedSpaceLinear();
+        size_t leftToRead = length - readCnt;
+        toRead = (leftToRead < linearLength) ? leftToRead : linearLength;
+        memcpy(&pData[readCnt], &m_cb.pArray[m_cb.tracker.start], toRead * sizeof(dataType_t));
+        m_cb.tracker.start = ((m_cb.tracker.start + toRead) % (int32_t)m_cb.tracker.numElements);
+    }
+
+    return readCnt;
+}
+
+/**\brief   Read newest element.
+ *
+ * \param   pData   - Pointer to place where data is to be returned
+ *
+ * \return  false for no data
+ */
+template <class dataType_t>
+bool CCBBuffer<dataType_t>::readNewest(dataType_t * pData)
+{
+    bool empty = this->isEmpty();
+
+    if(m_useMutex)
+    {
+
+    }
+
+    if(!empty)
+    {
+        size_t endButOne = ((m_cb.tracker.end + ((int32_t)m_cb.tracker.numElements - 1)) % (int32_t)m_cb.tracker.numElements);
+        *pData = m_cb.pArray[endButOne];
+    }
+
+    return !empty;
+}
+
+#endif /* CIRCULAR_BUFFER_H --------------------------------------------------*/

--- a/Firmware/communication/ascii_protocol.cpp
+++ b/Firmware/communication/ascii_protocol.cpp
@@ -26,20 +26,36 @@
 
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+
+void setPosition(char * pStr, StreamSink& response_channel, bool use_checksum);
+void setPositionWL(char * pStr, StreamSink& response_channel, bool use_checksum);
+void setVelocity(char * pStr, StreamSink& response_channel, bool use_checksum);
+void setCurrent(char * pStr, StreamSink& response_channel, bool use_checksum);
+void setTrapezoidTrajectory(char * pStr, StreamSink& response_channel, bool use_checksum);
+void getFeedback(char * pStr, StreamSink& response_channel, bool use_checksum);
+void help(char * pStr, StreamSink& response_channel, bool use_checksum);
+void infoDump(char * pStr, StreamSink& response_channel, bool use_checksum);
+void systemCTRL(char * pStr, StreamSink& response_channel, bool use_checksum);
+void readProperty(char * pStr, StreamSink& response_channel, bool use_checksum);
+void writeProperty(char * pStr, StreamSink& response_channel, bool use_checksum);
+void updateAxisWDG(char * pStr, StreamSink& response_channel, bool use_checksum);
+void unknownCMD(char * pStr, StreamSink& response_channel, bool use_checksum);
+
 /* Function implementations --------------------------------------------------*/
 
 // @brief Sends a line on the specified output.
 template<typename ... TArgs>
 void respond(StreamSink& output, bool include_checksum, const char * fmt, TArgs&& ... args) {
     char response[64];
+
     size_t len = snprintf(response, sizeof(response), fmt, std::forward<TArgs>(args)...);
     output.process_bytes((uint8_t*)response, len, nullptr); // TODO: use process_all instead
-    if (include_checksum) {
+    if (include_checksum)
+    {
         uint8_t checksum = 0;
         for (size_t i = 0; i < len; ++i)
             checksum ^= response[i];
-        len = snprintf(response, sizeof(response), "*%u", checksum);
-        output.process_bytes((uint8_t*)response, len, nullptr);
+        output.process_bytes((uint8_t*)response, snprintf(response, sizeof(response), "*%u", checksum), nullptr);
     }
     output.process_bytes((const uint8_t*)"\r\n", 2, nullptr);
 }
@@ -59,7 +75,8 @@ void ASCII_protocol_process_line(const uint8_t* buffer, size_t len, StreamSink& 
             len = i;
             break;
         }
-        if (checksum_start > i) {
+        if (checksum_start > i)
+        {
             if (buffer[i] == '*') {
                 checksum_start = i + 1;
             } else {
@@ -77,7 +94,7 @@ void ASCII_protocol_process_line(const uint8_t* buffer, size_t len, StreamSink& 
     bool use_checksum = (checksum_start < len);
     if (use_checksum) {
         unsigned int received_checksum;
-        sscanf((const char *)cmd + checksum_start, "%u", &received_checksum);
+        sscanf(&cmd[checksum_start], "%u", &received_checksum);
         if (received_checksum != checksum)
             return;
         len = checksum_start - 1; // prune checksum and asterisk
@@ -86,186 +103,272 @@ void ASCII_protocol_process_line(const uint8_t* buffer, size_t len, StreamSink& 
     cmd[len] = 0; // null-terminate
 
     // check incoming packet type
-    if (cmd[0] == 'p') { // position control
-        unsigned motor_number;
-        float pos_setpoint, vel_feed_forward, current_feed_forward;
-        int numscan = sscanf(cmd, "p %u %f %f %f", &motor_number, &pos_setpoint, &vel_feed_forward, &current_feed_forward);
-        if (numscan < 2) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else if (motor_number >= AXIS_COUNT) {
-            respond(response_channel, use_checksum, "invalid motor %u", motor_number);
-        } else {
-            if (numscan < 3)
-                vel_feed_forward = 0.0f;
-            if (numscan < 4)
-                current_feed_forward = 0.0f;
-            Axis* axis = axes[motor_number];
-            axis->controller_.set_pos_setpoint(pos_setpoint, vel_feed_forward, current_feed_forward);
-            axis->watchdog_feed();
-        }
-
-    } else if (cmd[0] == 'q') { // position control with limits
-        unsigned motor_number;
-        float pos_setpoint, vel_limit, current_lim;
-        int numscan = sscanf(cmd, "q %u %f %f %f", &motor_number, &pos_setpoint, &vel_limit, &current_lim);
-        if (numscan < 2) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else if (motor_number >= AXIS_COUNT) {
-            respond(response_channel, use_checksum, "invalid motor %u", motor_number);
-        } else {
-            Axis* axis = axes[motor_number];
-            axis->controller_.pos_setpoint_ = pos_setpoint;
-            if (numscan >= 3)
-                axis->controller_.config_.vel_limit = vel_limit;
-            if (numscan >= 4)
-                axis->motor_.config_.current_lim = current_lim;
-
-            axis->watchdog_feed();
-        }
-
-    } else if (cmd[0] == 'v') { // velocity control
-        unsigned motor_number;
-        float vel_setpoint, current_feed_forward;
-        int numscan = sscanf(cmd, "v %u %f %f", &motor_number, &vel_setpoint, &current_feed_forward);
-        if (numscan < 2) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else if (motor_number >= AXIS_COUNT) {
-            respond(response_channel, use_checksum, "invalid motor %u", motor_number);
-        } else {
-            if (numscan < 3)
-                current_feed_forward = 0.0f;
-            Axis* axis = axes[motor_number];
-            axis->controller_.set_vel_setpoint(vel_setpoint, current_feed_forward);
-            axis->watchdog_feed();
-        }
-
-    } else if (cmd[0] == 'c') { // current control
-        unsigned motor_number;
-        float current_setpoint;
-        int numscan = sscanf(cmd, "c %u %f", &motor_number, &current_setpoint);
-        if (numscan < 2) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else if (motor_number >= AXIS_COUNT) {
-            respond(response_channel, use_checksum, "invalid motor %u", motor_number);
-        } else {
-            Axis* axis = axes[motor_number];
-            axis->controller_.set_current_setpoint(current_setpoint);
-            axis->watchdog_feed();
-        }
-
-    } else if (cmd[0] == 't') { // trapezoidal trajectory
-        unsigned motor_number;
-        float goal_point;
-        int numscan = sscanf(cmd, "t %u %f", &motor_number, &goal_point);
-        if (numscan < 2) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else if (motor_number >= AXIS_COUNT) {
-            respond(response_channel, use_checksum, "invalid motor %u", motor_number);
-        } else {
-            Axis* axis = axes[motor_number];
-            axis->controller_.move_to_pos(goal_point);
-            axis->watchdog_feed();
-        }
-
-    } else if (cmd[0] == 'f') { // feedback
-        unsigned motor_number;
-        int numscan = sscanf(cmd, "f %u", &motor_number);
-        if (numscan < 1) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else if (motor_number >= AXIS_COUNT) {
-            respond(response_channel, use_checksum, "invalid motor %u", motor_number);
-        } else {
-            respond(response_channel, use_checksum, "%f %f",
-                    (double)axes[motor_number]->encoder_.pos_estimate_,
-                    (double)axes[motor_number]->encoder_.vel_estimate_);
-        }
-
-    } else if (cmd[0] == 'h') {  // Help
-        respond(response_channel, use_checksum, "Please see documentation for more details");
-        respond(response_channel, use_checksum, "");
-        respond(response_channel, use_checksum, "Available commands syntax reference:");
-        respond(response_channel, use_checksum, "Position: q axis pos vel-lim I-lim");
-        respond(response_channel, use_checksum, "Position: p axis pos vel-ff I-ff");
-        respond(response_channel, use_checksum, "Velocity: v axis vel I-ff");
-        respond(response_channel, use_checksum, "Current: c axis I");
-        respond(response_channel, use_checksum, "");
-        respond(response_channel, use_checksum, "Properties start at odrive root, such as axis0.requested_state");
-        respond(response_channel, use_checksum, "Read: r property");
-        respond(response_channel, use_checksum, "Write: w property value");
-        respond(response_channel, use_checksum, "");
-        respond(response_channel, use_checksum, "Save config: ss");
-        respond(response_channel, use_checksum, "Erase config: se");
-        respond(response_channel, use_checksum, "Reboot: sr");
-
-    } else if (cmd[0] == 'i'){ // Dump device info
-        // respond(response_channel, use_checksum, "Signature: %#x", STM_ID_GetSignature());
-        // respond(response_channel, use_checksum, "Revision: %#x", STM_ID_GetRevision());
-        // respond(response_channel, use_checksum, "Flash Size: %#x KiB", STM_ID_GetFlashSize());
-        respond(response_channel, use_checksum, "Hardware version: %d.%d-%dV", HW_VERSION_MAJOR, HW_VERSION_MINOR, HW_VERSION_VOLTAGE);
-        respond(response_channel, use_checksum, "Firmware version: %d.%d.%d", FW_VERSION_MAJOR, FW_VERSION_MINOR, FW_VERSION_REVISION);
-        respond(response_channel, use_checksum, "Serial number: %s", serial_number_str);
-
-    } else if (cmd[0] == 's'){ // System
-        if(cmd[1] == 's') { // Save config
-            save_configuration();
-        } else if (cmd[1] == 'e'){ // Erase config
-            erase_configuration();
-        } else if (cmd[1] == 'r'){ // Reboot
-            NVIC_SystemReset();
-        }
-
-    } else if (cmd[0] == 'r') { // read property
-        char name[MAX_LINE_LENGTH];
-        int numscan = sscanf(cmd, "r %" TO_STR(MAX_LINE_LENGTH) "s", name);
-        if (numscan < 1) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else {
-            Endpoint* endpoint = application_endpoints_->get_by_name(name, sizeof(name));
-            if (!endpoint) {
-                respond(response_channel, use_checksum, "invalid property");
-            } else {
-                char response[10];
-                bool success = endpoint->get_string(response, sizeof(response));
-                if (!success)
-                    respond(response_channel, use_checksum, "not implemented");
-                else
-                    respond(response_channel, use_checksum, response);
-            }
-        }
-
-    } else if (cmd[0] == 'w') { // write property
-        char name[MAX_LINE_LENGTH];
-        char value[MAX_LINE_LENGTH];
-        int numscan = sscanf(cmd, "w %" TO_STR(MAX_LINE_LENGTH) "s %" TO_STR(MAX_LINE_LENGTH) "s", name, value);
-        if (numscan < 1) {
-            respond(response_channel, use_checksum, "invalid command format");
-        } else {
-            Endpoint* endpoint = application_endpoints_->get_by_name(name, sizeof(name));
-            if (!endpoint) {
-                respond(response_channel, use_checksum, "invalid property");
-            } else {
-                bool success = endpoint->set_string(value, sizeof(value));
-                if (!success)
-                    respond(response_channel, use_checksum, "not implemented");
-            }
-        }
-
-    }else if (cmd[0] == 'u') { // Update axis watchdog. 
-        unsigned motor_number;
-        int numscan = sscanf(cmd, "u %u", &motor_number);
-        if(numscan < 1){
-            respond(response_channel, use_checksum, "invalid command format");
-        } else if (motor_number >= AXIS_COUNT) {
-            respond(response_channel, use_checksum, "invalid motor %u", motor_number);
-        }else {
-            axes[motor_number]->watchdog_feed();
-        }
-
-    } else if (cmd[0] != 0) {
-        respond(response_channel, use_checksum, "unknown command");
+    switch(cmd[0])
+    {
+        case 'p': setPosition(cmd, response_channel, use_checksum);             break;  // position control
+        case 'q': setPositionWL(cmd, response_channel, use_checksum);           break;  // position control with limits
+        case 'v': setVelocity(cmd, response_channel, use_checksum);             break;  // velocity control
+        case 'c': setCurrent(cmd, response_channel, use_checksum);              break;  // current control
+        case 't': setTrapezoidTrajectory(cmd, response_channel, use_checksum);  break;  // trapezoidal trajectory
+        case 'f': getFeedback(cmd, response_channel, use_checksum);             break;  // feedback
+        case 'h': help(cmd, response_channel, use_checksum);                    break;  // Help
+        case 'i': infoDump(cmd, response_channel, use_checksum);                break;  // Dump device info
+        case 's': systemCTRL(cmd, response_channel, use_checksum);              break;  // System
+        case 'r': readProperty(cmd, response_channel,  use_checksum);           break;  // read property
+        case 'w': writeProperty(cmd, response_channel, use_checksum);           break;  // write property
+        case 'u': updateAxisWDG(cmd, response_channel, use_checksum);           break;  // Update axis watchdog. 
+        default : unknownCMD(nullptr, response_channel, use_checksum);          break;
     }
 }
 
+// @brief Executes the set position command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void setPosition(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    unsigned motor_number;
+    float pos_setpoint, vel_feed_forward, current_feed_forward;
+
+    int numscan = sscanf(pStr, "p %u %f %f %f", &motor_number, &pos_setpoint, &vel_feed_forward, &current_feed_forward);
+    if (numscan < 2) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else if (motor_number >= AXIS_COUNT) {
+        respond(response_channel, use_checksum, "invalid motor %u", motor_number);
+    } else {
+        if (numscan < 3)
+            vel_feed_forward = 0.0f;
+        if (numscan < 4)
+            current_feed_forward = 0.0f;
+        Axis* axis = axes[motor_number];
+        axis->controller_.set_pos_setpoint(pos_setpoint, vel_feed_forward, current_feed_forward);
+        axis->watchdog_feed();
+    }
+}
+
+// @brief Executes the set position with current and velocity limit command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void setPositionWL(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    unsigned motor_number;
+    float pos_setpoint, vel_limit, current_lim;
+
+    int numscan = sscanf(pStr, "q %u %f %f %f", &motor_number, &pos_setpoint, &vel_limit, &current_lim);
+    if (numscan < 2) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else if (motor_number >= AXIS_COUNT) {
+        respond(response_channel, use_checksum, "invalid motor %u", motor_number);
+    } else {
+        Axis* axis = axes[motor_number];
+        axis->controller_.pos_setpoint_ = pos_setpoint;
+        if (numscan >= 3)
+            axis->controller_.config_.vel_limit = vel_limit;
+        if (numscan >= 4)
+            axis->motor_.config_.current_lim = current_lim;
+
+        axis->watchdog_feed();
+    }
+}
+
+// @brief Executes the set velocity command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void setVelocity(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    unsigned motor_number;
+    float vel_setpoint, current_feed_forward;
+    int numscan = sscanf(pStr, "v %u %f %f", &motor_number, &vel_setpoint, &current_feed_forward);
+    if (numscan < 2) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else if (motor_number >= AXIS_COUNT) {
+        respond(response_channel, use_checksum, "invalid motor %u", motor_number);
+    } else {
+        if (numscan < 3)
+            current_feed_forward = 0.0f;
+        Axis* axis = axes[motor_number];
+        axis->controller_.set_vel_setpoint(vel_setpoint, current_feed_forward);
+        axis->watchdog_feed();
+    }
+}
+
+// @brief Executes the set current limit command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void setCurrent(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    unsigned motor_number;
+    float current_setpoint;
+
+    if (sscanf(pStr, "c %u %f", &motor_number, &current_setpoint) < 2) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else if (motor_number >= AXIS_COUNT) {
+        respond(response_channel, use_checksum, "invalid motor %u", motor_number);
+    } else {
+        Axis* axis = axes[motor_number];
+        axis->controller_.set_current_setpoint(current_setpoint);
+        axis->watchdog_feed();
+    }
+}
+
+// @brief Executes the set trapezoid trajectory command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void setTrapezoidTrajectory(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    unsigned motor_number;
+    float goal_point;
+
+    if (sscanf(pStr, "t %u %f", &motor_number, &goal_point) < 2) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else if (motor_number >= AXIS_COUNT) {
+        respond(response_channel, use_checksum, "invalid motor %u", motor_number);
+    } else {
+        Axis* axis = axes[motor_number];
+        axis->controller_.move_to_pos(goal_point);
+        axis->watchdog_feed();
+    }
+}
+
+// @brief Executes the get position and velocity feedback command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void getFeedback(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    unsigned motor_number;
+
+    if (sscanf(pStr, "f %u", &motor_number) < 1) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else if (motor_number >= AXIS_COUNT) {
+        respond(response_channel, use_checksum, "invalid motor %u", motor_number);
+    } else {
+        Axis* axis = axes[motor_number];
+        respond(response_channel, use_checksum, "%f %f",
+                (double)axis->encoder_.pos_estimate_,
+                (double)axis->encoder_.vel_estimate_);
+    }
+}
+
+// @brief Shows help text
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void help(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    (void)pStr;
+    respond(response_channel, use_checksum, "Please see documentation for more details");
+    respond(response_channel, use_checksum, "");
+    respond(response_channel, use_checksum, "Available commands syntax reference:");
+    respond(response_channel, use_checksum, "Position: q axis pos vel-lim I-lim");
+    respond(response_channel, use_checksum, "Position: p axis pos vel-ff I-ff");
+    respond(response_channel, use_checksum, "Velocity: v axis vel I-ff");
+    respond(response_channel, use_checksum, "Current: c axis I");
+    respond(response_channel, use_checksum, "");
+    respond(response_channel, use_checksum, "Properties start at odrive root, such as axis0.requested_state");
+    respond(response_channel, use_checksum, "Read: r property");
+    respond(response_channel, use_checksum, "Write: w property value");
+    respond(response_channel, use_checksum, "");
+    respond(response_channel, use_checksum, "Save config: ss");
+    respond(response_channel, use_checksum, "Erase config: se");
+    respond(response_channel, use_checksum, "Reboot: sr");
+}
+
+// @brief Gets the hardware, firmware and serial details
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void infoDump(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    // respond(response_channel, use_checksum, "Signature: %#x", STM_ID_GetSignature());
+    // respond(response_channel, use_checksum, "Revision: %#x", STM_ID_GetRevision());
+    // respond(response_channel, use_checksum, "Flash Size: %#x KiB", STM_ID_GetFlashSize());
+    respond(response_channel, use_checksum, "Hardware version: %d.%d-%dV", HW_VERSION_MAJOR, HW_VERSION_MINOR, HW_VERSION_VOLTAGE);
+    respond(response_channel, use_checksum, "Firmware version: %d.%d.%d", FW_VERSION_MAJOR, FW_VERSION_MINOR, FW_VERSION_REVISION);
+    respond(response_channel, use_checksum, "Serial number: %s", serial_number_str);
+}
+
+// @brief Executes the system control command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void systemCTRL(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    switch (pStr[1])
+    {
+        case 's':   save_configuration();   break;  // Save config
+        case 'e':   erase_configuration();  break;  // Erase config
+        case 'r':   NVIC_SystemReset();     break;  // Reboot
+        default:    /* default */           break;
+    }
+}
+
+// @brief Executes the read parameter command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void readProperty(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    char name[MAX_LINE_LENGTH];
+
+    if (sscanf(pStr, "r %" TO_STR(MAX_LINE_LENGTH) "s", name) < 1) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else {
+        Endpoint* endpoint = application_endpoints_->get_by_name(name, sizeof(name));
+        if (!endpoint) {
+            respond(response_channel, use_checksum, "invalid property");
+        } else {
+            char response[10];
+            respond(response_channel, use_checksum, (endpoint->get_string(response, sizeof(response))) ? response : "not implemented");
+        }
+    }
+}
+
+// @brief Executes the set write position command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void writeProperty(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    char name[MAX_LINE_LENGTH];
+    char value[MAX_LINE_LENGTH];
+
+    if (sscanf(pStr, "w %" TO_STR(MAX_LINE_LENGTH) "s %" TO_STR(MAX_LINE_LENGTH) "s", name, value) < 1) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else {
+        Endpoint* endpoint = application_endpoints_->get_by_name(name, sizeof(name));
+        if (!endpoint) {
+            respond(response_channel, use_checksum, "invalid property");
+        } else {
+            if (!endpoint->set_string(value, sizeof(value))) {
+                respond(response_channel, use_checksum, "not implemented");
+            }
+        }
+    }
+}
+
+// @brief Executes the motor watchdog update command
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void updateAxisWDG(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    unsigned motor_number;
+
+    if(sscanf(pStr, "u %u", &motor_number) < 1) {
+        respond(response_channel, use_checksum, "invalid command format");
+    } else if (motor_number >= AXIS_COUNT) {
+        respond(response_channel, use_checksum, "invalid motor %u", motor_number);
+    } else {
+        axes[motor_number]->watchdog_feed();
+    }
+}
+
+// @brief Sends the unknown command response
+// @param pStr buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
+void unknownCMD(char * pStr, StreamSink& response_channel, bool use_checksum) {
+    (void)pStr;
+    respond(response_channel, use_checksum, "unknown command");
+}
+
+// @brief Parses the received ASCII char stream
+// @param buffer buffer of ASCII encoded values
+// @param response_channel reference to the stream to respond on
+// @param use_checksum bool to indicate whether a checksum is required on response
 void ASCII_protocol_parse_stream(const uint8_t* buffer, size_t len, StreamSink& response_channel) {
     static uint8_t parse_buffer[MAX_LINE_LENGTH];
     static bool read_active = true;

--- a/Firmware/communication/interface_uart.cpp
+++ b/Firmware/communication/interface_uart.cpp
@@ -1,10 +1,8 @@
 
 #include "interface_uart.h"
-
 #include "ascii_protocol.hpp"
-
+#include "CircularBuffer.hpp"
 #include <MotorControl/utils.h>
-
 #include <fibre/protocol.hpp>
 #include <usart.h>
 #include <cmsis_os.h>
@@ -14,30 +12,35 @@
 #define UART_RX_BUFFER_SIZE 64
 
 // DMA open loop continous circular buffer
-// 1ms delay periodic, chase DMA ptr around
-static uint8_t dma_rx_buffer[UART_RX_BUFFER_SIZE];
-static uint32_t dma_last_rcv_idx;
+static uint8_t dma_rx_buffer[2];
+
+static uint8_t RXBuffer[UART_RX_BUFFER_SIZE];
+CCBBuffer<uint8_t> CRXCircularBuffer(RXBuffer, sizeof(RXBuffer), false, false);
 
 // FIXME: the stdlib doesn't know about CMSIS threads, so this is just a global variable
 // static thread_local uint32_t deadline_ms = 0;
 
 osThreadId uart_thread;
 
-
-class UART4Sender : public StreamSink {
+class UART4Sender 
+    : public StreamSink
+{
 public:
-    int process_bytes(const uint8_t* buffer, size_t length, size_t* processed_bytes) {
+    UART4Sender()
+        : CTXCircularBuffer(TXBuffer, sizeof(TXBuffer), false, false){}
+    int process_bytes(const uint8_t* buffer, size_t length, size_t* processed_bytes)
+    {
         // Loop to ensure all bytes get sent
-        while (length) {
-            size_t chunk = length < UART_TX_BUFFER_SIZE ? length : UART_TX_BUFFER_SIZE;
+        while (length)
+        {
+            size_t chunk = (length < UART_TX_BUFFER_SIZE) ? length : UART_TX_BUFFER_SIZE;
             // wait for USB interface to become ready
             // TODO: implement ring buffer to get a more continuous stream of data
             // if (osSemaphoreWait(sem_uart_dma, deadline_to_timeout(deadline_ms)) != osOK)
             if (osSemaphoreWait(sem_uart_dma, PROTOCOL_SERVER_TIMEOUT_MS) != osOK)
                 return -1;
-            // transmit chunk
-            memcpy(tx_buf_, buffer, chunk);
-            if (HAL_UART_Transmit_DMA(&huart4, tx_buf_, chunk) != HAL_OK)
+			// transmit chunk
+            if (HAL_UART_Transmit_DMA(&huart4, (uint8_t *)memcpy(tx_buf_, buffer, chunk), chunk) != HAL_OK)
                 return -1;
             buffer += chunk;
             length -= chunk;
@@ -50,9 +53,11 @@ public:
     size_t get_free_space() { return SIZE_MAX; }
 private:
     uint8_t tx_buf_[UART_TX_BUFFER_SIZE];
+    uint8_t TXBuffer[UART_TX_BUFFER_SIZE];
+    CCBBuffer<uint8_t> CTXCircularBuffer;
 } uart4_stream_output;
-StreamSink* uart4_stream_output_ptr = &uart4_stream_output;
 
+StreamSink * uart4_stream_output_ptr = &uart4_stream_output;
 StreamBasedPacketSink uart4_packet_output(uart4_stream_output);
 BidirectionalPacketBasedChannel uart4_channel(uart4_packet_output);
 StreamToPacketSegmenter uart4_stream_input(uart4_channel);
@@ -61,47 +66,79 @@ static void uart_server_thread(void * ctx) {
     (void) ctx;
 
     for (;;) {
-        // Check for UART errors and restart recieve DMA transfer if required
-        if (huart4.ErrorCode != HAL_UART_ERROR_NONE) {
-            HAL_UART_AbortReceive(&huart4);
-            HAL_UART_Receive_DMA(&huart4, dma_rx_buffer, sizeof(dma_rx_buffer));
-        }
-        // Fetch the circular buffer "write pointer", where it would write next
-        uint32_t new_rcv_idx = UART_RX_BUFFER_SIZE - huart4.hdmarx->Instance->NDTR;
+        uint8_t RXData[UART_RX_BUFFER_SIZE] = {0};
+        size_t length = CRXCircularBuffer.read(RXData, sizeof(RXData));
 
-        // deadline_ms = timeout_to_deadline(PROTOCOL_SERVER_TIMEOUT_MS);
-        // Process bytes in one or two chunks (two in case there was a wrap)
-        if (new_rcv_idx < dma_last_rcv_idx) {
-            uart4_stream_input.process_bytes(dma_rx_buffer + dma_last_rcv_idx,
-                    UART_RX_BUFFER_SIZE - dma_last_rcv_idx, nullptr); // TODO: use process_all
-            ASCII_protocol_parse_stream(dma_rx_buffer + dma_last_rcv_idx,
-                    UART_RX_BUFFER_SIZE - dma_last_rcv_idx, uart4_stream_output);
-            dma_last_rcv_idx = 0;
-        }
-        if (new_rcv_idx > dma_last_rcv_idx) {
-            uart4_stream_input.process_bytes(dma_rx_buffer + dma_last_rcv_idx,
-                    new_rcv_idx - dma_last_rcv_idx, nullptr); // TODO: use process_all
-            ASCII_protocol_parse_stream(dma_rx_buffer + dma_last_rcv_idx,
-                    new_rcv_idx - dma_last_rcv_idx, uart4_stream_output);
-            dma_last_rcv_idx = new_rcv_idx;
-        }
+        uart4_stream_input.process_bytes(RXData, length, nullptr); // TODO: use process_all
+        ASCII_protocol_parse_stream(RXData, length, uart4_stream_output);
 
-        osDelay(1);
+        osThreadSuspend(uart_thread);
     };
 }
 
 void start_uart_server() {
     // DMA is set up to recieve in a circular buffer forever.
-    // We dont use interrupts to fetch the data, instead we periodically read
-    // data out of the circular buffer into a parse buffer, controlled by a state machine
+    // We dont use interrupts to fetch the data directly, DMA transfers the data into a 
+	// circular buffer and signals the uart task to deal with the data. Data is then 
+	// taken out of the circular buffer into a parse buffer, controlled by a state machine
     HAL_UART_Receive_DMA(&huart4, dma_rx_buffer, sizeof(dma_rx_buffer));
-    dma_last_rcv_idx = UART_RX_BUFFER_SIZE - huart4.hdmarx->Instance->NDTR;
 
     // Start UART communication thread
-    osThreadDef(uart_server_thread_def, uart_server_thread, osPriorityNormal, 0, 1024 /* the ascii protocol needs considerable stack space */);
+    osThreadDef(uart_server_thread_def,
+                uart_server_thread,
+                osPriorityNormal,
+                0,
+                1024 /* the ascii protocol needs considerable stack space */);
     uart_thread = osThreadCreate(osThread(uart_server_thread_def), NULL);
 }
 
+/**
+  * @brief  UART error callbacks.
+  * @param  huart pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval None
+  */
+ void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
+    if(&huart4 == huart) {
+        HAL_UART_AbortReceive(&huart4);
+        HAL_UART_Receive_DMA(&huart4, dma_rx_buffer, sizeof(dma_rx_buffer));
+    }
+}
+
+/**
+  * @brief  Tx Transfer completed callbacks.
+  * @param  huart pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval None
+  */
 void HAL_UART_TxCpltCallback(UART_HandleTypeDef* huart) {
-    osSemaphoreRelease(sem_uart_dma);
+    if(&huart4 == huart) {
+        osSemaphoreRelease(sem_uart_dma);
+    }
+}
+
+/**
+  * @brief  Rx Half Transfer completed callbacks.
+  * @param  huart pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval None
+  */
+void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart) {
+    if(&huart4 == huart) {
+        CRXCircularBuffer.write(&huart->pRxBuffPtr[0], 1);
+        osThreadResume(uart_thread);
+    }
+}
+
+/**
+  * @brief  Rx Transfer completed callbacks.
+  * @param  huart pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval None
+  */
+void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
+    if(&huart4 == huart) {
+        CRXCircularBuffer.write(&huart->pRxBuffPtr[1], 1);
+        osThreadResume(uart_thread);
+    }
 }


### PR DESCRIPTION
Added templated circular buffer code for quickly adding self contained circular buffers

Changed UART handler to use a wake/suspend mechanism and to use the DMA to transfer 2 bytes at a time. Using the half and full transfer complete interrupts, each character received can be read out of the UART register immediately, significantly reducing UART register overwrite conditions. The two DMA ISR's can then transfer the received characters into a circular buffer and signal the UART task should wake up and read the data back out of the circular buffer at it's earliest convenience. The task can wake, handle the received characters and then go back to sleep. This method reduces the data handling overhead of received characters and allows the task to sleep unless needed.

The transfer error handling has been moved in to the error detection ISR to allow for immediate handling of UART errors rather than waiting for the task to wake up and handle the UART.

Menu function has been split up into individual functions and the if else tree has been replaced with a switch statement allowing for faster code execution and easier code maintenance.