### PR TITLE
Add support for extended CAN IDs

### DIFF
--- a/Firmware/MotorControl/axis.hpp
+++ b/Firmware/MotorControl/axis.hpp
@@ -86,7 +86,8 @@ public:
         LockinConfig_t calibration_lockin = default_calibration();
         LockinConfig_t sensorless_ramp = default_sensorless();
         LockinConfig_t lockin;
-        uint8_t can_node_id = 0; // Both axes will have the same id to start
+        uint32_t can_node_id = 0; // Both axes will have the same id to start
+        bool can_node_id_extended = false;
         uint32_t can_heartbeat_rate_ms = 100;
     };
 
@@ -314,6 +315,7 @@ public:
                     make_protocol_property("finish_on_distance", &config_.lockin.finish_on_distance),
                     make_protocol_property("finish_on_enc_idx", &config_.lockin.finish_on_enc_idx)),
                 make_protocol_property("can_node_id", &config_.can_node_id),
+                make_protocol_property("can_node_id_extended", &config_.can_node_id_extended),
                 make_protocol_property("can_heartbeat_rate_ms", &config_.can_heartbeat_rate_ms)),
             make_protocol_object("motor", motor_.make_protocol_definitions()),
             make_protocol_object("controller", controller_.make_protocol_definitions()),

--- a/Firmware/communication/can_simple.cpp
+++ b/Firmware/communication/can_simple.cpp
@@ -26,7 +26,7 @@ void CANSimple::handle_can_message(can_Message_t& msg) {
 
     bool validAxis = false;
     for (uint8_t i = 0; i < AXIS_COUNT; i++) {
-        if (axes[i]->config_.can_node_id == nodeID) {
+        if ((axes[i]->config_.can_node_id == nodeID) && (axes[i]->config_.can_node_id_extended == msg.isExt)) {
             axis = axes[i];
             if (!validAxis) {
                 validAxis = true;
@@ -137,7 +137,7 @@ void CANSimple::get_motor_error_callback(Axis* axis, can_Message_t& msg) {
         can_Message_t txmsg;
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_MOTOR_ERROR;  // heartbeat ID
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         txmsg.buf[0] = axis->motor_.error_;
@@ -154,7 +154,7 @@ void CANSimple::get_encoder_error_callback(Axis* axis, can_Message_t& msg) {
         can_Message_t txmsg;
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_ENCODER_ERROR;  // heartbeat ID
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         txmsg.buf[0] = axis->encoder_.error_;
@@ -171,7 +171,7 @@ void CANSimple::get_sensorless_error_callback(Axis* axis, can_Message_t& msg) {
         can_Message_t txmsg;
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_SENSORLESS_ERROR;  // heartbeat ID
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         txmsg.buf[0] = axis->sensorless_estimator_.error_;
@@ -184,7 +184,7 @@ void CANSimple::get_sensorless_error_callback(Axis* axis, can_Message_t& msg) {
 }
 
 void CANSimple::set_axis_nodeid_callback(Axis* axis, can_Message_t& msg) {
-    axis->config_.can_node_id = msg.buf[0] & 0x3F;  // Node ID bitmask
+    axis->config_.can_node_id = can_getSignal<uint32_t>(msg, 0, 32, true);
 }
 
 void CANSimple::set_axis_requested_state_callback(Axis* axis, can_Message_t& msg) {
@@ -199,7 +199,7 @@ void CANSimple::get_encoder_estimates_callback(Axis* axis, can_Message_t& msg) {
         can_Message_t txmsg;
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_ENCODER_ESTIMATES;  // heartbeat ID
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         // Undefined behaviour!
@@ -230,7 +230,7 @@ void CANSimple::get_sensorless_estimates_callback(Axis* axis, can_Message_t& msg
         can_Message_t txmsg;
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_SENSORLESS_ESTIMATES;  // heartbeat ID
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         // Undefined behaviour!
@@ -261,7 +261,7 @@ void CANSimple::get_encoder_count_callback(Axis* axis, can_Message_t& msg) {
         can_Message_t txmsg;
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_ENCODER_COUNT;
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         txmsg.buf[0] = axis->encoder_.shadow_count_;
@@ -325,7 +325,7 @@ void CANSimple::get_iq_callback(Axis* axis, can_Message_t& msg) {
         can_Message_t txmsg;
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_IQ;
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         uint32_t floatBytes;
@@ -354,7 +354,7 @@ void CANSimple::get_vbus_voltage_callback(Axis* axis, can_Message_t& msg) {
 
         txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_VBUS_VOLTAGE;
-        txmsg.isExt = false;
+        txmsg.isExt = axis->config_.can_node_id_extended;
         txmsg.len = 8;
 
         uint32_t floatBytes;
@@ -386,7 +386,7 @@ void CANSimple::send_heartbeat(Axis* axis) {
     can_Message_t txmsg;
     txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_ODRIVE_HEARTBEAT;  // heartbeat ID
-    txmsg.isExt = false;
+    txmsg.isExt = axis->config_.can_node_id_extended;
     txmsg.len = 8;
 
     // Axis errors in 1st 32-bit value
@@ -403,8 +403,8 @@ void CANSimple::send_heartbeat(Axis* axis) {
     odCAN->write(txmsg);
 }
 
-uint8_t CANSimple::get_node_id(uint32_t msgID) {
-    return ((msgID >> NUM_CMD_ID_BITS) & 0x03F);  // Upper 6 bits
+uint32_t CANSimple::get_node_id(uint32_t msgID) {
+    return (msgID >> NUM_CMD_ID_BITS);  // Upper 6 or more bits
 }
 
 uint8_t CANSimple::get_cmd_id(uint32_t msgID) {

--- a/Firmware/communication/can_simple.hpp
+++ b/Firmware/communication/can_simple.hpp
@@ -64,7 +64,7 @@ class CANSimple {
     static void clear_errors_callback(Axis* axis, can_Message_t& msg);
 
     // Utility functions
-    static uint8_t get_node_id(uint32_t msgID);
+    static uint32_t get_node_id(uint32_t msgID);
     static uint8_t get_cmd_id(uint32_t msgID);
 
     // Fetch a specific signal from the message

--- a/docs/can-protocol.md
+++ b/docs/can-protocol.md
@@ -16,7 +16,7 @@ We've implemented a very basic CAN protocol that we call "CAN Simple" to get use
 ### CAN Frame
 At its most basic, the CAN Simple frame looks like this:
 
-* Upper 6 bits - Node ID - max 0x3F
+* Upper 6 bits - Node ID - max 0x3F (or 0xFFFFFF when using extended CAN IDs)
 * Lower 5 bits - Command ID - max 0x1F
 
 To understand how the Node ID and Command ID interact, let's look at an example
@@ -40,7 +40,7 @@ CMD ID | Name | Sender | Signals | Start byte | Signal Type | Bits | Factor | Of
 0x003 | Get Motor Error\* | Axis  | Motor Error | 0 | Unsigned Int | 32 | 1 | 0 | Intel
 0x004 | Get Encoder Error\*  | Axis | Encoder Error | 0 | Unsigned Int | 32 | 1 | 0 | Intel
 0x005 | Get Sensorless Error\* | Axis | Sensorless Error | 0 | Unsigned Int | 32 | 1 | 0 | Intel
-0x006 | Set Axis Node ID | Master | Axis CAN Node ID | 0 | Unsigned Int | 16 | 1 | 0 | Intel
+0x006 | Set Axis Node ID | Master | Axis CAN Node ID | 0 | Unsigned Int | 32 | 1 | 0 | Intel
 0x007 | Set Axis Requested State | Master | Axis Requested State | 0 | Unsigned Int | 32 | 1 | 0 | Intel
 0x008 | Set Axis Startup Config | Master | - Not yet implemented - | - | - | - | - | - | -
 0x009 | Get Encoder Estimates\* | Master | Encoder Pos Estimate<br>Encoder Vel Estimate | 0<br>4 | IEEE 754 Float<br>IEEE 754 Float | 32<br>32 | 1<br>1 | 0<br>0 | Intel<br>Intel
@@ -72,7 +72,7 @@ Configuration of the CAN parameters should be done via USB before putting the de
 
 To set the desired baud rate, use `<odrv>.can.set_baud_rate(<value>)`.  The baud rate can be done without rebooting the device.  If you'd like to keep the baud rate, simply call `<odrv>.save_configuration()` before rebooting.
 
-Each axis looks like a separate node on the bus.  Thus, they've inherited a new configuration property: `can_node_id`.  This ID can be from 0 to 63 (0x3F) inclusive.
+Each axis looks like a separate node on the bus. Thus, they both have the two properties `can_node_id` and `can_node_id_extended`. The node ID can be from 0 to 63 (0x3F) inclusive, or, if extended CAN IDs are used, from 0 to 16777215 (0xFFFFFF).
 
 ### Example Configuration
 

--- a/tools/odrive/tests/test_runner.py
+++ b/tools/odrive/tests/test_runner.py
@@ -679,7 +679,7 @@ def select_params(param_options):
     # Select parameters from the resource list
     # (this could be arbitrarily complex to improve parallelization of the tests)
     for combination in get_combinations(param_options):
-        if all_unique(combination):
+        if all_unique([x for x in combination if isinstance(x, Component)]):
             return list(combination)
 
     return None
@@ -708,7 +708,7 @@ def run(tests):
         test_cases = list(test.get_test_cases(testrig))
 
         if len(test_cases) == 0:
-            logger.warn('no resources are available to conduct the test {}'.format(type(test).__name__))
+            logger.warn('no test cases are available to conduct the test {}'.format(type(test).__name__))
             continue
         
         for test_case in test_cases:


### PR DESCRIPTION
Previously, coexistence with devices that use extended CAN IDs was not
possible since the ODrive would simply clip the 18 upper bits of an
extended message ID. See #409.

This adds proper support for extended CAN IDs by changing
`can_node_id` from 8 to 32 bit and introducing the new option
`can_node_id_extended`.