### PR TITLE
Fix hang on compile on Windows

### DIFF
--- a/Firmware/Tupfile.lua
+++ b/Firmware/Tupfile.lua
@@ -1,6 +1,22 @@
 
 tup.include('build.lua')
 
+-- If we simply invoke python or python3 on a pristine Windows 10, it will try
+-- to open the Microsoft Store which will not work and hang tup instead. The
+-- command "python --version" does not open the Microsoft Store.
+-- On some systems this may return a python2 command if Python3 is not installed.
+function find_python3()
+    success, python_version = run_now("python3 --version")
+    if success then return "python3" end
+    io.stderr:write("This should go to stderr\n")
+    success, python_version = run_now("python --version")
+    if success then return "python" end
+    error("Python 3 not found.")
+end
+
+python_command = find_python3()
+print('Using python command "'..python_command..'"')
+
 -- Switch between board versions
 boardversion = tup.getconfig("BOARD_VERSION")
 if boardversion == "v3.1" then
@@ -146,7 +162,7 @@ build{
 }
 
 tup.frule{
-    command='python ../tools/odrive/version.py --output %o',
+    command=python_command..' ../tools/odrive/version.py --output %o',
     outputs={'build/version.h'}
 }
 

--- a/Firmware/build.lua
+++ b/Firmware/build.lua
@@ -12,6 +12,14 @@ function string:split(sep)
     return fields
 end
 
+function run_now(command)
+    local handle
+    handle = io.popen(command)
+    local output = handle:read("*a")
+    local rc = {handle:close()}
+    return rc[1], output
+end
+
 -- Very basic parser to retrieve variables from a Makefile
 function parse_makefile_vars(makefile)
     vars = {}

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -35,7 +35,7 @@ The recommended tools for ODrive development are:
  * **ARM GNU Compiler**: For cross-compiling code
  * **ARM GDB**: For debugging the code and stepping through on the device
  * **OpenOCD**: For flashing the ODrive with the STLink/v2 programmer
- * **Python**: For running the Python tools
+ * **Python**: For running the Python tools (`odrivetool`). Also required for compiling firmware.
 
 See below for specific installation instructions for your OS.
 
@@ -92,6 +92,7 @@ Some instructions in this document may assume that you're using a bash command p
   * __Note 2__: 8-2018-q4-major seems to have a bug on Windows.  Please use 7-2018-q2-update.
 * [Tup](http://gittup.org/tup/index.html)
 * [GNU MCU Eclipse's Windows Build Tools](https://github.com/gnu-mcu-eclipse/windows-build-tools/releases)
+* [Python 3](https://www.python.org/downloads/)
 * [OpenOCD](https://github.com/xpack-dev-tools/openocd-xpack/releases/). 
 * [ST-Link/V2 Drivers](http://www.st.com/web/en/catalog/tools/FM147/SC1887/PF260219)
 


### PR DESCRIPTION
Windows 10 includes since version 1903 a python stub which is supposed
to open the MS Store if python is invoked but not installed. However
when invoked from tup, the stub simply hangs without output.

With this change we first check the python version (something that the
Windows stub does not interer with) before we invoke it.