### PR TITLE
Allow reversal of homing direction and ability to clear SPI Error Rate

### DIFF
--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -173,10 +173,9 @@ bool Axis::do_checks() {
     // controller_.do_checks();
 
     // Check for endstop presses
-    bool vel_dependent_stopping = (current_state_ == AXIS_STATE_HOMING) && (controller_.config_.control_mode >= Controller::CONTROL_MODE_VELOCITY_CONTROL);
-    if (min_endstop_.config_.enabled && min_endstop_.get_state() && (!vel_dependent_stopping || controller_.vel_setpoint_ < 0.0f)) {
+    if (min_endstop_.config_.enabled && min_endstop_.get_state() && !(current_state_ == AXIS_STATE_HOMING)) {
         error_ |= ERROR_MIN_ENDSTOP_PRESSED;
-    } else if (max_endstop_.config_.enabled && max_endstop_.get_state() && (!vel_dependent_stopping || controller_.vel_setpoint_ > 0.0f)) {
+    } else if (max_endstop_.config_.enabled && max_endstop_.get_state() && !(current_state_ == AXIS_STATE_HOMING)) {
         error_ |= ERROR_MAX_ENDSTOP_PRESSED;
     }
 

--- a/Firmware/MotorControl/axis.hpp
+++ b/Firmware/MotorControl/axis.hpp
@@ -106,6 +106,7 @@ public:
         controller_.error_ = Controller::ERROR_NONE;
         sensorless_estimator_.error_ = SensorlessEstimator::ERROR_NONE;
         encoder_.error_ = Encoder::ERROR_NONE;
+        encoder_.spi_error_rate_ = 0.0f;
 
         error_ = ERROR_NONE;
     }

--- a/docs/endstops.md
+++ b/docs/endstops.md
@@ -96,7 +96,7 @@ Name |  Type | Default
 --- | -- | -- 
 homing_speed | float | 2000.0f
 
-`homing_speed` is the axis travel speed during homing, in counts/second.
+`homing_speed` is the axis travel speed during homing, in counts/second.  If you are using SPI based encoders and the axis is homing in the wrong direction, you can enter a negative value for the homing speed and a negative value for the minimum endstop offset. 
 
 
 ### Performing the Homing Sequence


### PR DESCRIPTION
If a user is using SPI based encoders they are currently unable to reverse the direction of homing to the minimum endstop with a proper offset. The following allows the endstop check to allow both sign velocities. 

If a user is using SPI based encoders that provide inconsistent data on startup they may receive `ERROR_ABS_SPI_COM_FAIL` that is cleared on calls to `axis.clear_errors()`, but this error will immediately raised again as the `encoder.spi_error_rate_` has no way to be reset. The following resets `spi_error_rate` upon `axis.clear_errors()`.