### PR TITLE
Call Encoder::setup() before Motor::setup()

### DIFF
--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -245,13 +245,13 @@ int odrive_main(void) {
     // must happen after communication is initialized
     pwm_in_init();
 
+    for(auto& axis : axes){
+        axis->encoder_.setup();
+    }
+
     // Setup hardware for all components
     for (size_t i = 0; i < AXIS_COUNT; ++i) {
         axes[i]->setup();
-    }
-
-    for(auto& axis : axes){
-        axis->encoder_.setup();
     }
 
     // Start PWM and enable adc interrupts/callbacks


### PR DESCRIPTION
`abs_spi_cs_pin_init()` sets `GPIO_PULLUP` on the configured CS pins. Without this, using AMT2xx encoders on GPIO pins 7 and 8, `DRV8301_readSpi()` will always read a value of `0xFFFF` causing `DRV8301_enable()` to get stuck in an infinite loop. This PR switches the order of operations to configure CS GPIO pins before attempting to communicate with the DRV8301. In my testing this fixes https://github.com/madcowswe/ODrive/issues/420