### PR TITLE
Changed bash shebangs to a more general version.

### DIFF
--- a/Firmware/build.sh
+++ b/Firmware/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds the firmware with the configuration specified by
 # environment variables named CONFIG_...
 # If DEPLOY is set, the deliverables are copied to Firmware/deploy/*

--- a/Firmware/find_programmer.sh
+++ b/Firmware/find_programmer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 openocd -d3 -f board/stm32f4discovery.cfg  -c "hla_serial wrong_serial" 2>&1 | \
     xxd -p | \
     tr -d '\n' | \

--- a/tools/odrive/tests/test_runner.py
+++ b/tools/odrive/tests/test_runner.py
@@ -794,7 +794,7 @@ if args.setup_host:
         if not os.path.isfile('/usr/share/arduino/hardware/tools/teensy_post_compile_old'):
             os.rename('/usr/share/arduino/hardware/tools/teensy_post_compile', '/usr/share/arduino/hardware/tools/teensy_post_compile_old')
         with open('/usr/share/arduino/hardware/tools/teensy_post_compile', 'w') as scr:
-            scr.write('#!/bin/bash\n')
+            scr.write('#!/usr/bin/env bash\n')
             scr.write('if [ "$ARDUINO_COMPILE_DESTINATION" != "" ]; then\n')
             scr.write('  cp -r ${2#-path=}/*.ino.hex ${ARDUINO_COMPILE_DESTINATION}\n')
             scr.write('fi\n')


### PR DESCRIPTION
Some unix operating systems(including mine) do not have bash under `/bin/bash`. This modifies the shebang to lookup bash in the environment.  This is the most portable way I know of. 