### PR TITLE
Fix protocol bugs

### DIFF
--- a/Firmware/communication/interface_usb.cpp
+++ b/Firmware/communication/interface_usb.cpp
@@ -61,7 +61,7 @@ public:
         // Loop to ensure all bytes get sent
         while (length) {
             size_t chunk = length < USB_TX_DATA_SIZE ? length : USB_TX_DATA_SIZE;
-            if (output_.process_packet(buffer, length) != 0)
+            if (output_.process_packet(buffer, chunk) != 0)
                 return -1;
             buffer += chunk;
             length -= chunk;

--- a/Firmware/fibre/cpp/include/fibre/introspection.hpp
+++ b/Firmware/fibre/cpp/include/fibre/introspection.hpp
@@ -96,7 +96,7 @@ public:
 private:
     Introspectable get_direct_child(const char * name, size_t length) const {
         for (size_t i = 0; i < type_info_->property_table_length_; ++i) {
-            if (!strncmp(name, type_info_->property_table_[i].name, length)) {
+            if (!strncmp(name, type_info_->property_table_[i].name, length) && (length == strlen(type_info_->property_table_[i].name))) {
                 Introspectable result;
                 result.storage_ = type_info_->get_child(storage_, i);
                 result.type_info_ = type_info_->property_table_[i].type_info;


### PR DESCRIPTION
 - Fix incorrect use of snprintf (#438)
 - Fix TreatPacketSinkAsStreamSink::process_bytes() quitting when being passed more than 64 bytes (#438)
 - Fix motor subtree being unreachable from ASCII protocol (triggered by the `motor_thermistor` object that was added in #419)