### PR TITLE
Rc v0.5.0 fix random error encoder

### DIFF
--- a/Firmware/MotorControl/encoder.cpp
+++ b/Firmware/MotorControl/encoder.cpp
@@ -27,7 +27,7 @@ void Encoder::setup() {
 
     mode_ = config_.mode;
     if(mode_ & MODE_FLAG_ABS){
-        //abs_spi_cs_pin_init();
+        abs_spi_cs_pin_init();
         abs_spi_init();
         if (axis_->controller_.config_.anticogging.pre_calibrated) {
             axis_->controller_.anticogging_valid_ = true;
@@ -414,12 +414,10 @@ void Encoder::abs_spi_cb(){
 }
 
 void Encoder::abs_spi_cs_pin_init(){
-    mode_ = config_.mode;
-    if(mode_ & MODE_FLAG_ABS){
     // Decode cs pin
     abs_spi_cs_port_ = get_gpio_port_by_pin(config_.abs_spi_cs_gpio_pin);
     abs_spi_cs_pin_ = get_gpio_pin_by_pin(config_.abs_spi_cs_gpio_pin);
-
+    HAL_GPIO_WritePin(abs_spi_cs_port_, abs_spi_cs_pin_, GPIO_PIN_SET); // at for cs pin not pull down when the cs pin init
     // Init cs pin
     HAL_GPIO_DeInit(abs_spi_cs_port_, abs_spi_cs_pin_);
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -431,7 +429,7 @@ void Encoder::abs_spi_cs_pin_init(){
 
     // Write pin high
     HAL_GPIO_WritePin(abs_spi_cs_port_, abs_spi_cs_pin_, GPIO_PIN_SET);
-    }
+    
 }
 
 bool Encoder::update() {

--- a/Firmware/MotorControl/encoder.cpp
+++ b/Firmware/MotorControl/encoder.cpp
@@ -27,7 +27,7 @@ void Encoder::setup() {
 
     mode_ = config_.mode;
     if(mode_ & MODE_FLAG_ABS){
-        abs_spi_cs_pin_init();
+        //abs_spi_cs_pin_init();
         abs_spi_init();
         if (axis_->controller_.config_.anticogging.pre_calibrated) {
             axis_->controller_.anticogging_valid_ = true;
@@ -414,6 +414,8 @@ void Encoder::abs_spi_cb(){
 }
 
 void Encoder::abs_spi_cs_pin_init(){
+    mode_ = config_.mode;
+    if(mode_ & MODE_FLAG_ABS){
     // Decode cs pin
     abs_spi_cs_port_ = get_gpio_port_by_pin(config_.abs_spi_cs_gpio_pin);
     abs_spi_cs_pin_ = get_gpio_pin_by_pin(config_.abs_spi_cs_gpio_pin);
@@ -429,6 +431,7 @@ void Encoder::abs_spi_cs_pin_init(){
 
     // Write pin high
     HAL_GPIO_WritePin(abs_spi_cs_port_, abs_spi_cs_pin_, GPIO_PIN_SET);
+    }
 }
 
 bool Encoder::update() {

--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -226,10 +226,6 @@ void vApplicationIdleHook(void) {
 
 int odrive_main(void) {
 
-    //init CS Pi first
-    for(auto& axis : axes){
-        axis->encoder_.abs_spi_cs_pin_init();
-    }  
     // Start ADC for temperature measurements and user measurements
     start_general_purpose_adc();
 
@@ -239,7 +235,7 @@ int odrive_main(void) {
         SetGPIO12toUART();
     }
 #endif
-    osDelay(100);
+    //osDelay(100);
     // Init communications (this requires the axis objects to be constructed)
     init_communication();
 

--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -225,6 +225,11 @@ void vApplicationIdleHook(void) {
 }
 
 int odrive_main(void) {
+
+    //init CS Pi first
+    for(auto& axis : axes){
+        axis->encoder_.abs_spi_cs_pin_init();
+    }  
     // Start ADC for temperature measurements and user measurements
     start_general_purpose_adc();
 

--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -239,7 +239,7 @@ int odrive_main(void) {
         SetGPIO12toUART();
     }
 #endif
-    //osDelay(100);
+    osDelay(100);
     // Init communications (this requires the axis objects to be constructed)
     init_communication();
 


### PR DESCRIPTION
when I connect to 2 SPI encoders. It's a random error:

- Can't connect to 2 encoders (only an encoder work and another encoder much reset power of the encoder )

-> Add HAL_GPIO_WritePin(abs_spi_cs_port_, abs_spi_cs_pin_, GPIO_PIN_SET);  // make cs pin not pull down when the cs pin init