### PR TITLE
Increase UART polling frequency from 1kHz to 8kHz

### DIFF
--- a/Firmware/MotorControl/axis.hpp
+++ b/Firmware/MotorControl/axis.hpp
@@ -163,6 +163,10 @@ public:
             // TODO: change arming logic to arm after waiting
             bool main_continue = update_handler();
 
+            if (axis_num_ == 0) {
+                uart_poll(); // TODO: move to board-level control loop once it exists
+            }
+
             // Check we meet deadlines after queueing
             ++loop_counter_;
 

--- a/Firmware/MotorControl/odrive_main.h
+++ b/Firmware/MotorControl/odrive_main.h
@@ -12,6 +12,7 @@
 #include <fibre/protocol.hpp>
 #include <communication/interface_usb.h>
 #include <communication/interface_i2c.h>
+#include <communication/interface_uart.h>
 extern "C" {
 #endif
 

--- a/Firmware/communication/interface_uart.h
+++ b/Firmware/communication/interface_uart.h
@@ -14,6 +14,7 @@ extern osThreadId uart_thread;
 extern const uint32_t stack_size_uart_thread;
 
 void start_uart_server(void);
+void uart_poll(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Addresses #428.

At 1Mbaud/s and 8kHz polling frequency a maximum of 12.5 bytes can arrive per polling interval.
It is therefore unlikely that a higher polling frequency than 8kHz would add significant additional benefit.
