### PR TITLE
Fix endstop configuration, update docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Unreleased Features
 Please add a note of your changes below this heading if you make a Pull Request.
 
+### Changed
+
+* Use DMA for DRV8301 setup
+* Make NVM configuration code more dynamic so that the layout doesn't have to be known at compile time.
+* GPIO initialization logic was changed. GPIOs now need to be explicitly set to the mode corresponding to the feature that they are used by. See `<odrv>.config.gpioX_mode`.
+* Previously, if two components used the same interrupt pin (e.g. step input for axis0 and axis1) then the one that was configured later would override the other one. Now this is no longer the case (the old component remains the owner of the pin).
+
 ### API Miration Notes
 
 * `enable_uart` and `uart_baudrate` were renamed to `enable_uart0` and `uart0_baudrate`.
 * `enable_i2c_instead_of_can` was replaced by the separate settings `enable_i2c0` and `enable_can0`.
-
+* `<axis>.motor.gate_driver` was moved to `<axis>.gate_driver`.
+* `<axis>.min_endstop.pullup` and `<axis>.max_endstop.pullup` were removed. Use `<odrv>.config.gpioX_mode = GPIO_MODE_DIGITAL / GPIO_MODE_DIGITAL_PULL_UP / GPIO_MODE_DIGITAL_PULL_DOWN` instead.
 
 # Release Candidate
 ## [0.5.1] - Date TBD
@@ -50,7 +58,6 @@ Please add a note of your changes below this heading if you make a Pull Request.
 * Using an STM32F405 .svd file allows CortexDebug to view registers during debugging
 * Added scripts for building via docker.
 * Added ability to change uart baudrate via fibre
-* Introduced GPIO modes. GPIOs now need to be explicitly set to the mode corresponding to the feature that they are used by. See `<odrv>.config.gpioX_mode`.
 
 ### Changed
 * Changed ratiometric `motor.config.current_lim_tolerance` to absolute `motor.config.current_lim_margin`
@@ -65,9 +72,6 @@ Please add a note of your changes below this heading if you make a Pull Request.
 * Reboot on `erase_configuration()`. This avoids unexpected behavior of a subsequent `save_configuration()` call, since the configuration is only erased from NVM, not from RAM.
 * Change `motor.get_inverter_temp()` to use a property which was already being sampled at `motor.inverter_temp`
 * Fixed a numerical issue in the trajectory planner that could cause sudden jumps of the position setpoint
-* Use DMA for DRV8301 setup
-* Make NVM configuration code more dynamic so that the layout doesn't have to be known at compile time
-* Refactor GPIO code. Note that if two components use the same interrupt pin (e.g. step input for axis0 and axis1) then previously the one that was configured later would override the other one. Now this is no longer the case (the old component remains the owner of the pin).
 
 ## [0.4.12] - 2020-05-06
 ### Fixed

--- a/Firmware/Board/v3/Inc/board.h
+++ b/Firmware/Board/v3/Inc/board.h
@@ -53,10 +53,10 @@
     ODriveIntf::GPIO_MODE_DIGITAL, \
     ODriveIntf::GPIO_MODE_ENC0, \
     ODriveIntf::GPIO_MODE_ENC0, \
-    ODriveIntf::GPIO_MODE_DIGITAL, \
+    ODriveIntf::GPIO_MODE_DIGITAL_PULL_DOWN, \
     ODriveIntf::GPIO_MODE_ENC1, \
     ODriveIntf::GPIO_MODE_ENC1, \
-    ODriveIntf::GPIO_MODE_DIGITAL, \
+    ODriveIntf::GPIO_MODE_DIGITAL_PULL_DOWN, \
     ODriveIntf::GPIO_MODE_CAN0, \
     ODriveIntf::GPIO_MODE_CAN0,
 

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -146,10 +146,6 @@ void Axis::decode_step_dir_pins() {
 // @brief (de)activates step/dir input
 void Axis::set_step_dir_active(bool active) {
     if (active) {
-        // Set up the step/direction GPIOs as input
-        dir_gpio_.config(GPIO_MODE_INPUT, GPIO_NOPULL);
-        step_gpio_.config(GPIO_MODE_INPUT, GPIO_PULLDOWN);
-
         // Subscribe to rising edges of the step GPIO
         if (!step_gpio_.subscribe(true, false, step_cb_wrapper, this)) {
             odrv.misconfigured_ = true;

--- a/Firmware/MotorControl/encoder.cpp
+++ b/Firmware/MotorControl/encoder.cpp
@@ -103,7 +103,6 @@ void Encoder::enc_index_cb() {
 
 void Encoder::set_idx_subscribe(bool override_enable) {
     if (config_.use_index && (override_enable || !config_.find_idx_on_lockin_only)) {
-        index_gpio_.config(GPIO_MODE_INPUT, GPIO_PULLDOWN);
         if (!index_gpio_.subscribe(true, false, enc_index_cb_wrapper, this)) {
             odrv.misconfigured_ = true;
         }

--- a/Firmware/MotorControl/endstop.cpp
+++ b/Firmware/MotorControl/endstop.cpp
@@ -24,19 +24,12 @@ bool Endstop::get_state() {
 }
 
 bool Endstop::apply_config() {
-    set_enabled(config_.enabled);
+    debounceTimer_.reset();
+    if (config_.enabled) {
+        debounceTimer_.start();
+    } else {
+        debounceTimer_.stop();
+    }
     debounceTimer_.setIncrement(config_.debounce_ms * 0.001f);
     return true;
-}
-
-void Endstop::set_enabled(bool enable) {
-    debounceTimer_.reset();
-    if (config_.gpio_num != 0) {
-        if (enable) {
-            Stm32Gpio gpio = get_gpio(config_.gpio_num);
-            gpio.config(GPIO_MODE_INPUT, config_.pullup ? GPIO_PULLUP : GPIO_PULLDOWN);
-            debounceTimer_.start();
-        } else
-            debounceTimer_.stop();
-    }
 }

--- a/Firmware/MotorControl/endstop.hpp
+++ b/Firmware/MotorControl/endstop.hpp
@@ -10,7 +10,6 @@ class Endstop {
         uint16_t gpio_num = 0;
         bool enabled = false;
         bool is_active_high = false;
-        bool pullup = true;
 
         // custom setters
         Endstop* parent = nullptr;

--- a/Firmware/MotorControl/endstop.hpp
+++ b/Firmware/MotorControl/endstop.hpp
@@ -25,7 +25,6 @@ class Endstop {
     Axis* axis_ = nullptr;
 
     bool apply_config();
-    void set_enabled(bool enabled);
 
     void update();
     bool get_state();

--- a/Firmware/MotorControl/main.cpp
+++ b/Firmware/MotorControl/main.cpp
@@ -407,7 +407,10 @@ extern "C" int main(void) {
         GPIO_InitStruct.Pin = get_gpio(i).pin_mask_;
 
         // Set Alternate Function setting for this GPIO mode
-        if (mode == ODriveIntf::GPIO_MODE_DIGITAL || mode == ODriveIntf::GPIO_MODE_ANALOG_IN) {
+        if (mode == ODriveIntf::GPIO_MODE_DIGITAL ||
+            mode == ODriveIntf::GPIO_MODE_DIGITAL_PULL_UP ||
+            mode == ODriveIntf::GPIO_MODE_DIGITAL_PULL_DOWN ||
+            mode == ODriveIntf::GPIO_MODE_ANALOG_IN) {
             GPIO_InitStruct.Alternate = 0;
         } else {
             auto it = std::find_if(
@@ -425,6 +428,16 @@ extern "C" int main(void) {
             case ODriveIntf::GPIO_MODE_DIGITAL: {
                 GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
                 GPIO_InitStruct.Pull = GPIO_NOPULL;
+                GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+            } break;
+            case ODriveIntf::GPIO_MODE_DIGITAL_PULL_UP: {
+                GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+                GPIO_InitStruct.Pull = GPIO_PULLUP;
+                GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+            } break;
+            case ODriveIntf::GPIO_MODE_DIGITAL_PULL_DOWN: {
+                GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+                GPIO_InitStruct.Pull = GPIO_PULLDOWN;
                 GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
             } break;
             case ODriveIntf::GPIO_MODE_ANALOG_IN: {

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -915,7 +915,6 @@ interfaces:
           enabled: {type: bool, c_setter: set_enabled}
           offset: float32
           is_active_high: bool
-          pullup: bool
           debounce_ms: {type: uint32, c_setter: set_debounce_ms}
 
 
@@ -926,6 +925,10 @@ valuetypes:
         doc: |
           The pin can be used for one or more of these functions:
           Step, dir, enable, encoder index, hall effect encoder, SPI encoder nCS (this one is exclusive).
+      DigitalPullUp:
+        doc: Same as `Digital` but with the internal pull-up resistor enabled.
+      DigitalPullDown:
+        doc: Same as `Digital` but with the internal pull-down resistor enabled.
       AnalogIn:
         doc: |
           The pin can be used for one or more of these functions:

--- a/docs/encoders.md
+++ b/docs/encoders.md
@@ -135,6 +135,30 @@ If you are using an encoder with an index signal, another problem that has been 
 * when performing an index_search, the motor does not return to the same position each time.
 One easy step that _might_ fix the noise on the Z input has been to solder a 22nF-47nF capacitor to the Z pin and the GND pin on the underside of the ODrive board. 
 
+## Hall feedback pinout
+If position accuracy is not a concern, you can use A/B/C hall effect encoders for position feedback.
+
+To use this mode, configure the corresponding encoder mode: `<encoder>.config.mode = ENCODER_MODE_HALL`. Configure the corresponding GPIOs as digital inputs:
+
+For encoder 0:
+
+    <odrv>.config.gpio9_mode = GPIO_MODE_DIGITAL
+    <odrv>.config.gpio10_mode = GPIO_MODE_DIGITAL
+    <odrv>.config.gpio11_mode = GPIO_MODE_DIGITAL
+
+For encoder 1:
+
+    <odrv>.config.gpio12_mode = GPIO_MODE_DIGITAL
+    <odrv>.config.gpio13_mode = GPIO_MODE_DIGITAL
+    <odrv>.config.gpio14_mode = GPIO_MODE_DIGITAL
+
+In this mode, the pinout on the encoder port is as follows:
+
+| Label on ODrive | Hall feedback |
+|-----------------|---------------|
+| A               | Hall A        |
+| B               | Hall B        |
+| Z               | Hall C        |
 
 ## SPI Encoders
 

--- a/docs/hoverboard.md
+++ b/docs/hoverboard.md
@@ -41,6 +41,9 @@ The hall feedback has 6 states for every pole pair in the motor. Since we have 1
 ```txt
 odrv0.axis0.encoder.config.mode = ENCODER_MODE_HALL
 odrv0.axis0.encoder.config.cpr = 90
+odrv0.config.gpio9_mode = GPIO_MODE_DIGITAL
+odrv0.config.gpio10_mode = GPIO_MODE_DIGITAL
+odrv0.config.gpio11_mode = GPIO_MODE_DIGITAL
 ```
 
 Since the hall feedback only has 90 counts per revolution, we want to reduce the velocity tracking bandwidth to get smoother velocity estimates.

--- a/tools/odrive/enums.py
+++ b/tools/odrive/enums.py
@@ -5,17 +5,19 @@
 
 # ODrive.GpioMode
 GPIO_MODE_DIGITAL                        = 0
-GPIO_MODE_ANALOG_IN                      = 1
-GPIO_MODE_UART0                          = 2
-GPIO_MODE_UART1                          = 3
-GPIO_MODE_UART2                          = 4
-GPIO_MODE_CAN0                           = 5
-GPIO_MODE_I2C0                           = 6
-GPIO_MODE_SPI0                           = 7
-GPIO_MODE_PWM0                           = 8
-GPIO_MODE_ENC0                           = 9
-GPIO_MODE_ENC1                           = 10
-GPIO_MODE_ENC2                           = 11
+GPIO_MODE_DIGITAL_PULL_UP                = 1
+GPIO_MODE_DIGITAL_PULL_DOWN              = 2
+GPIO_MODE_ANALOG_IN                      = 3
+GPIO_MODE_UART0                          = 4
+GPIO_MODE_UART1                          = 5
+GPIO_MODE_UART2                          = 6
+GPIO_MODE_CAN0                           = 7
+GPIO_MODE_I2C0                           = 8
+GPIO_MODE_SPI0                           = 9
+GPIO_MODE_PWM0                           = 10
+GPIO_MODE_ENC0                           = 11
+GPIO_MODE_ENC1                           = 12
+GPIO_MODE_ENC2                           = 13
 
 # ODrive.Can.Protocol
 PROTOCOL_SIMPLE                          = 0


### PR DESCRIPTION
HWIL test log:
 - f3fa0af5c1d626c7640ff8249a79a740dfeabd23: `encoder_test.py` and `step_dir_test.py` pass.