### PR TITLE
CAN handling improvements

### DIFF
--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -94,7 +94,7 @@ void Axis::clear_config() {
     config_ = {};
     config_.step_gpio_pin = default_step_gpio_pin_;
     config_.dir_gpio_pin = default_dir_gpio_pin_;
-    config_.can_node_id = axis_num_;
+    config_.can.node_id = axis_num_;
 }
 
 // @brief Sets up all components of the axis,
@@ -206,7 +206,7 @@ bool Axis::do_updates() {
     min_endstop_.update();
     max_endstop_.update();
     bool ret = check_for_errors();
-    odCAN->send_heartbeat(*this);
+    odCAN->send_cyclic(*this);
     return ret;
 }
 

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -206,7 +206,7 @@ bool Axis::do_updates() {
     min_endstop_.update();
     max_endstop_.update();
     bool ret = check_for_errors();
-    odCAN->send_heartbeat(this);
+    odCAN->send_heartbeat(*this);
     return ret;
 }
 

--- a/Firmware/MotorControl/axis.hpp
+++ b/Firmware/MotorControl/axis.hpp
@@ -32,6 +32,13 @@ public:
     static LockinConfig_t default_sensorless();
     static LockinConfig_t default_lockin();
 
+    struct CANConfig_t {
+        uint32_t node_id = 0;
+        bool is_extended = false;
+        uint32_t heartbeat_rate_ms = 100;
+        uint32_t encoder_rate_ms = 10;
+    };
+
     struct Config_t {
         bool startup_motor_calibration = false;   //<! run motor calibration at startup, skip otherwise
         bool startup_encoder_index_search = false; //<! run encoder index search after startup, skip otherwise
@@ -60,9 +67,8 @@ public:
         LockinConfig_t calibration_lockin = default_calibration();
         LockinConfig_t sensorless_ramp = default_sensorless();
         LockinConfig_t general_lockin;
-        uint32_t can_node_id = 0; // Both axes will have the same id to start
-        bool can_node_id_extended = false;
-        uint32_t can_heartbeat_rate_ms = 100;
+
+        CANConfig_t can;
 
         // custom setters
         Axis* parent = nullptr;
@@ -72,6 +78,11 @@ public:
 
     struct Homing_t {
         bool is_homed = false;
+    };
+
+    struct CAN_t {
+        uint32_t last_heartbeat = 0;
+        uint32_t last_encoder = 0;
     };
 
     enum thread_signals {
@@ -243,8 +254,9 @@ public:
     AxisState& current_state_ = task_chain_.front();
     uint32_t loop_counter_ = 0;
     LockinState lockin_state_ = LOCKIN_STATE_INACTIVE;
-    Homing_t homing_;
-    uint32_t last_heartbeat_ = 0;
+    Homing_t homing_;    
+    CAN_t can_;
+
 
     // watchdog
     uint32_t watchdog_current_value_= 0;

--- a/Firmware/Tests/test_can.cpp
+++ b/Firmware/Tests/test_can.cpp
@@ -39,6 +39,9 @@ TEST_SUITE("CAN Functions") {
         val = can_getSignal<uint16_t>(rxmsg, 0, 16, true, 1, 0);
         CHECK(val == 0x1234);
 
+        val = can_getSignal<uint16_t>(rxmsg, 0, 16, true);
+        CHECK(val == 0x1234);
+
         val = can_getSignal<uint16_t>(rxmsg, 0, 16, false, 1, 0);
         CHECK(val == 0x3412);
 

--- a/Firmware/communication/can_helpers.hpp
+++ b/Firmware/communication/can_helpers.hpp
@@ -42,17 +42,10 @@ T can_getSignal(can_Message_t msg, const uint8_t startBit, const uint8_t length,
     return retVal;
 }
 
-template<typename T>
-float can_getSignal(can_Message_t msg, const uint8_t startBit, const uint8_t length, const bool isIntel, const float factor, const float offset) {
-    T retVal = can_getSignal<T>(msg, startBit, length, isIntel);
-    return (retVal * factor) + offset;
-}
-
 template <typename T>
-void can_setSignal(can_Message_t& msg, const T& val, const uint8_t startBit, const uint8_t length, const bool isIntel, const float factor, const float offset) {
-    T scaledVal = (val - offset) / factor;
+void can_setSignal(can_Message_t& msg, const T& val, const uint8_t startBit, const uint8_t length, const bool isIntel) {
     uint64_t valAsBits = 0;
-    std::memcpy(&valAsBits, &scaledVal, sizeof(scaledVal));
+    std::memcpy(&valAsBits, &val, sizeof(val));
 
     uint64_t mask = (1ULL << length) - 1;
 
@@ -75,6 +68,18 @@ void can_setSignal(can_Message_t& msg, const T& val, const uint8_t startBit, con
         std::memcpy(msg.buf, &data, sizeof(data));
         std::reverse(std::begin(msg.buf), std::end(msg.buf));
     }
+}
+
+template<typename T>
+void can_setSignal(can_Message_t& msg, const T& val, const uint8_t startBit, const uint8_t length, const bool isIntel, const float factor, const float offset) {
+    T scaledVal = static_cast<T>((val - offset) / factor);
+    can_setSignal<T>(msg, scaledVal, startBit, length, isIntel);
+}
+
+template<typename T>
+float can_getSignal(can_Message_t msg, const uint8_t startBit, const uint8_t length, const bool isIntel, const float factor, const float offset) {
+    T retVal = can_getSignal<T>(msg, startBit, length, isIntel);
+    return (retVal * factor) + offset;
 }
 
 template <typename T>

--- a/Firmware/communication/can_helpers.hpp
+++ b/Firmware/communication/can_helpers.hpp
@@ -24,9 +24,9 @@ struct can_Signal_t {
 
 #include <iterator>
 template <typename T>
-T can_getSignal(can_Message_t msg, const uint8_t startBit, const uint8_t length, const bool isIntel) {
+constexpr T can_getSignal(can_Message_t msg, const uint8_t startBit, const uint8_t length, const bool isIntel) {
     uint64_t tempVal = 0;
-    uint64_t mask = (1ULL << length) - 1;
+    uint64_t mask = length < 64 ? (1ULL << length) - 1ULL : -1ULL;
 
     if (isIntel) {
         std::memcpy(&tempVal, msg.buf, sizeof(tempVal));
@@ -43,11 +43,11 @@ T can_getSignal(can_Message_t msg, const uint8_t startBit, const uint8_t length,
 }
 
 template <typename T>
-void can_setSignal(can_Message_t& msg, const T& val, const uint8_t startBit, const uint8_t length, const bool isIntel) {
+constexpr void can_setSignal(can_Message_t& msg, const T& val, const uint8_t startBit, const uint8_t length, const bool isIntel) {
     uint64_t valAsBits = 0;
     std::memcpy(&valAsBits, &val, sizeof(val));
 
-    uint64_t mask = (1ULL << length) - 1;
+    uint64_t mask = length < 64 ? (1ULL << length) - 1ULL : -1ULL;
 
     if (isIntel) {
         uint64_t data = 0;

--- a/Firmware/communication/can_helpers.hpp
+++ b/Firmware/communication/can_helpers.hpp
@@ -21,6 +21,10 @@ struct can_Signal_t {
     const float offset;
 };
 
+struct can_Cyclic_t {
+    uint32_t cycleTime_ms;
+    uint32_t lastTime_ms;
+};
 
 #include <iterator>
 template <typename T>

--- a/Firmware/communication/can_simple.cpp
+++ b/Firmware/communication/can_simple.cpp
@@ -118,7 +118,7 @@ void CANSimple::estop_callback(Axis& axis, const can_Message_t& msg) {
     axis.error_ |= Axis::ERROR_ESTOP_REQUESTED;
 }
 
-uint32_t CANSimple::get_motor_error_callback(const Axis& axis) {
+int32_t CANSimple::get_motor_error_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_MOTOR_ERROR;  // heartbeat ID
@@ -130,7 +130,7 @@ uint32_t CANSimple::get_motor_error_callback(const Axis& axis) {
     return odCAN->write(txmsg);
 }
 
-uint32_t CANSimple::get_encoder_error_callback(const Axis& axis) {
+int32_t CANSimple::get_encoder_error_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_ENCODER_ERROR;  // heartbeat ID
@@ -142,7 +142,7 @@ uint32_t CANSimple::get_encoder_error_callback(const Axis& axis) {
     return odCAN->write(txmsg);
 }
 
-uint32_t CANSimple::get_sensorless_error_callback(const Axis& axis) {
+int32_t CANSimple::get_sensorless_error_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_SENSORLESS_ERROR;  // heartbeat ID
@@ -166,7 +166,7 @@ void CANSimple::set_axis_startup_config_callback(Axis& axis, const can_Message_t
     // Not Implemented
 }
 
-uint32_t CANSimple::get_encoder_estimates_callback(const Axis& axis) {
+int32_t CANSimple::get_encoder_estimates_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_ENCODER_ESTIMATES;  // heartbeat ID
@@ -182,7 +182,7 @@ uint32_t CANSimple::get_encoder_estimates_callback(const Axis& axis) {
     return odCAN->write(txmsg);
 }
 
-uint32_t CANSimple::get_sensorless_estimates_callback(const Axis& axis) {
+int32_t CANSimple::get_sensorless_estimates_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_SENSORLESS_ESTIMATES;  // heartbeat ID
@@ -198,7 +198,7 @@ uint32_t CANSimple::get_sensorless_estimates_callback(const Axis& axis) {
     return odCAN->write(txmsg);
 }
 
-uint32_t CANSimple::get_encoder_count_callback(const Axis& axis) {
+int32_t CANSimple::get_encoder_count_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_ENCODER_COUNT;
@@ -252,7 +252,7 @@ void CANSimple::set_traj_inertia_callback(Axis& axis, const can_Message_t& msg) 
     axis.controller_.config_.inertia = can_getSignal<float>(msg, 0, 32, true);
 }
 
-uint32_t CANSimple::get_iq_callback(const Axis& axis) {
+int32_t CANSimple::get_iq_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_IQ;
@@ -267,7 +267,7 @@ uint32_t CANSimple::get_iq_callback(const Axis& axis) {
     return odCAN->write(txmsg);
 }
 
-uint32_t CANSimple::get_vbus_voltage_callback(const Axis& axis) {
+int32_t CANSimple::get_vbus_voltage_callback(const Axis& axis) {
     can_Message_t txmsg;
 
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
@@ -286,7 +286,7 @@ void CANSimple::clear_errors_callback(Axis& axis, const can_Message_t& msg) {
     axis.clear_errors();
 }
 
-uint32_t CANSimple::send_heartbeat(const Axis& axis) {
+int32_t CANSimple::send_heartbeat(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_ODRIVE_HEARTBEAT;  // heartbeat ID

--- a/Firmware/communication/can_simple.cpp
+++ b/Firmware/communication/can_simple.cpp
@@ -1,13 +1,12 @@
 
 #include "can_simple.hpp"
-#include <odrive_main.h>
 
-#include <cstring>
+#include <odrive_main.h>
 
 static constexpr uint8_t NUM_NODE_ID_BITS = 6;
 static constexpr uint8_t NUM_CMD_ID_BITS = 11 - NUM_NODE_ID_BITS;
 
-void CANSimple::handle_can_message(can_Message_t& msg) {
+void CANSimple::handle_can_message(const can_Message_t& msg) {
     // This functional way of handling the messages is neat and is much cleaner from
     // a data security point of view, but it will require some tweaking to fix the syntax.
     //
@@ -20,287 +19,278 @@ void CANSimple::handle_can_message(can_Message_t& msg) {
     // nodeID | CMD
     // 6 bits | 5 bits
     uint32_t nodeID = get_node_id(msg.id);
-    uint32_t cmd = get_cmd_id(msg.id);
 
-    Axis* axis = nullptr;
-
-    bool validAxis = false;
-    for (uint8_t i = 0; i < AXIS_COUNT; i++) {
-        if ((axes[i].config_.can_node_id == nodeID) && (axes[i].config_.can_node_id_extended == msg.isExt)) {
-            axis = &axes[i];
-            if (!validAxis) {
-                validAxis = true;
-            } else {
-                // Duplicate can IDs, don't assign to any axis
-                odCAN->set_error(ODriveCAN::ERROR_DUPLICATE_CAN_IDS);
-                validAxis = false;
-                break;
-            }
-        }
-    }
-
-    if (validAxis) {
-        axis->watchdog_feed();
-        switch (cmd) {
-            case MSG_CO_NMT_CTRL:
-                break;
-            case MSG_CO_HEARTBEAT_CMD:
-                break;
-            case MSG_ODRIVE_HEARTBEAT:
-                // We don't currently do anything to respond to ODrive heartbeat messages
-                break;
-            case MSG_ODRIVE_ESTOP:
-                estop_callback(axis, msg);
-                break;
-            case MSG_GET_MOTOR_ERROR:
-                get_motor_error_callback(axis, msg);
-                break;
-            case MSG_GET_ENCODER_ERROR:
-                get_encoder_error_callback(axis, msg);
-                break;
-            case MSG_GET_SENSORLESS_ERROR:
-                get_sensorless_error_callback(axis, msg);
-                break;
-            case MSG_SET_AXIS_NODE_ID:
-                set_axis_nodeid_callback(axis, msg);
-                break;
-            case MSG_SET_AXIS_REQUESTED_STATE:
-                set_axis_requested_state_callback(axis, msg);
-                break;
-            case MSG_SET_AXIS_STARTUP_CONFIG:
-                set_axis_startup_config_callback(axis, msg);
-                break;
-            case MSG_GET_ENCODER_ESTIMATES:
-                get_encoder_estimates_callback(axis, msg);
-                break;
-            case MSG_GET_ENCODER_COUNT:
-                get_encoder_count_callback(axis, msg);
-                break;
-            case MSG_SET_INPUT_POS:
-                set_input_pos_callback(axis, msg);
-                break;
-            case MSG_SET_INPUT_VEL:
-                set_input_vel_callback(axis, msg);
-                break;
-            case MSG_SET_INPUT_TORQUE:
-                set_input_torque_callback(axis, msg);
-                break;
-            case MSG_SET_CONTROLLER_MODES:
-                set_controller_modes_callback(axis, msg);
-                break;
-            case MSG_SET_VEL_LIMIT:
-                set_vel_limit_callback(axis, msg);
-                break;
-            case MSG_START_ANTICOGGING:
-                start_anticogging_callback(axis, msg);
-                break;
-            case MSG_SET_TRAJ_INERTIA:
-                set_traj_inertia_callback(axis, msg);
-                break;
-            case MSG_SET_TRAJ_ACCEL_LIMITS:
-                set_traj_accel_limits_callback(axis, msg);
-                break;
-            case MSG_SET_TRAJ_VEL_LIMIT:
-                set_traj_vel_limit_callback(axis, msg);
-                break;
-            case MSG_GET_IQ:
-                get_iq_callback(axis, msg);
-                break;
-            case MSG_GET_SENSORLESS_ESTIMATES:
-                get_sensorless_estimates_callback(axis, msg);
-                break;
-            case MSG_RESET_ODRIVE:
-                NVIC_SystemReset();
-                break;
-            case MSG_GET_VBUS_VOLTAGE:
-                get_vbus_voltage_callback(axis, msg);
-                break;
-            case MSG_CLEAR_ERRORS:
-                clear_errors_callback(axis, msg);
-                break;
-            default:
-                break;
+    for (auto& axis : axes) {
+        if ((axis.config_.can_node_id == nodeID) && (axis.config_.can_node_id_extended == msg.isExt)) {
+            doCommand(axis, msg);
+            return;
         }
     }
 }
 
-void CANSimple::nmt_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::doCommand(Axis& axis, const can_Message_t& msg) {
+    const uint32_t cmd = get_cmd_id(msg.id);
+    axis.watchdog_feed();
+    switch (cmd) {
+        case MSG_CO_NMT_CTRL:
+            break;
+        case MSG_CO_HEARTBEAT_CMD:
+            break;
+        case MSG_ODRIVE_HEARTBEAT:
+            // We don't currently do anything to respond to ODrive heartbeat messages
+            break;
+        case MSG_ODRIVE_ESTOP:
+            estop_callback(axis, msg);
+            break;
+        case MSG_GET_MOTOR_ERROR:
+            get_motor_error_callback(axis, msg);
+            break;
+        case MSG_GET_ENCODER_ERROR:
+            get_encoder_error_callback(axis, msg);
+            break;
+        case MSG_GET_SENSORLESS_ERROR:
+            get_sensorless_error_callback(axis, msg);
+            break;
+        case MSG_SET_AXIS_NODE_ID:
+            set_axis_nodeid_callback(axis, msg);
+            break;
+        case MSG_SET_AXIS_REQUESTED_STATE:
+            set_axis_requested_state_callback(axis, msg);
+            break;
+        case MSG_SET_AXIS_STARTUP_CONFIG:
+            set_axis_startup_config_callback(axis, msg);
+            break;
+        case MSG_GET_ENCODER_ESTIMATES:
+            get_encoder_estimates_callback(axis, msg);
+            break;
+        case MSG_GET_ENCODER_COUNT:
+            get_encoder_count_callback(axis, msg);
+            break;
+        case MSG_SET_INPUT_POS:
+            set_input_pos_callback(axis, msg);
+            break;
+        case MSG_SET_INPUT_VEL:
+            set_input_vel_callback(axis, msg);
+            break;
+        case MSG_SET_INPUT_TORQUE:
+            set_input_torque_callback(axis, msg);
+            break;
+        case MSG_SET_CONTROLLER_MODES:
+            set_controller_modes_callback(axis, msg);
+            break;
+        case MSG_SET_VEL_LIMIT:
+            set_vel_limit_callback(axis, msg);
+            break;
+        case MSG_START_ANTICOGGING:
+            start_anticogging_callback(axis, msg);
+            break;
+        case MSG_SET_TRAJ_INERTIA:
+            set_traj_inertia_callback(axis, msg);
+            break;
+        case MSG_SET_TRAJ_ACCEL_LIMITS:
+            set_traj_accel_limits_callback(axis, msg);
+            break;
+        case MSG_SET_TRAJ_VEL_LIMIT:
+            set_traj_vel_limit_callback(axis, msg);
+            break;
+        case MSG_GET_IQ:
+            get_iq_callback(axis, msg);
+            break;
+        case MSG_GET_SENSORLESS_ESTIMATES:
+            get_sensorless_estimates_callback(axis, msg);
+            break;
+        case MSG_RESET_ODRIVE:
+            NVIC_SystemReset();
+            break;
+        case MSG_GET_VBUS_VOLTAGE:
+            get_vbus_voltage_callback(axis, msg);
+            break;
+        case MSG_CLEAR_ERRORS:
+            clear_errors_callback(axis, msg);
+            break;
+        default:
+            break;
+    }
+}
+
+
+void CANSimple::nmt_callback(const Axis& axis, const can_Message_t& msg) {
     // Not implemented
 }
 
-void CANSimple::estop_callback(Axis* axis, can_Message_t& msg) {
-    axis->error_ |= Axis::ERROR_ESTOP_REQUESTED;
+void CANSimple::estop_callback(Axis& axis, const can_Message_t& msg) {
+    axis.error_ |= Axis::ERROR_ESTOP_REQUESTED;
 }
 
-void CANSimple::get_motor_error_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_motor_error_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_MOTOR_ERROR;  // heartbeat ID
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
-        can_setSignal(txmsg, axis->motor_.error_, 0, 32, true);
+        can_setSignal(txmsg, axis.motor_.error_, 0, 32, true);
 
         odCAN->write(txmsg);
     }
 }
 
-void CANSimple::get_encoder_error_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_encoder_error_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_ENCODER_ERROR;  // heartbeat ID
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
-        can_setSignal(txmsg, axis->encoder_.error_, 0, 32, true);
+        can_setSignal(txmsg, axis.encoder_.error_, 0, 32, true);
 
         odCAN->write(txmsg);
     }
 }
 
-void CANSimple::get_sensorless_error_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_sensorless_error_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_SENSORLESS_ERROR;  // heartbeat ID
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
-        can_setSignal(txmsg, axis->sensorless_estimator_.error_, 0, 32, true);
+        can_setSignal(txmsg, axis.sensorless_estimator_.error_, 0, 32, true);
 
         odCAN->write(txmsg);
     }
 }
 
-void CANSimple::set_axis_nodeid_callback(Axis* axis, can_Message_t& msg) {
-    axis->config_.can_node_id = can_getSignal<uint32_t>(msg, 0, 32, true);
+void CANSimple::set_axis_nodeid_callback(Axis& axis, const can_Message_t& msg) {
+    axis.config_.can_node_id = can_getSignal<uint32_t>(msg, 0, 32, true);
 }
 
-void CANSimple::set_axis_requested_state_callback(Axis* axis, can_Message_t& msg) {
-    axis->requested_state_ = static_cast<Axis::AxisState>(can_getSignal<int32_t>(msg, 0, 16, true));
+void CANSimple::set_axis_requested_state_callback(Axis& axis, const can_Message_t& msg) {
+    axis.requested_state_ = static_cast<Axis::AxisState>(can_getSignal<int32_t>(msg, 0, 16, true));
 }
-void CANSimple::set_axis_startup_config_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::set_axis_startup_config_callback(Axis& axis, const can_Message_t& msg) {
     // Not Implemented
 }
 
-void CANSimple::get_encoder_estimates_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_encoder_estimates_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_ENCODER_ESTIMATES;  // heartbeat ID
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
-        static_assert(sizeof(float) == sizeof(axis->encoder_.pos_estimate_));
-        static_assert(sizeof(float) == sizeof(axis->encoder_.vel_estimate_));
+        static_assert(sizeof(float) == sizeof(axis.encoder_.pos_estimate_));
+        static_assert(sizeof(float) == sizeof(axis.encoder_.vel_estimate_));
 
-        can_setSignal<float>(txmsg, axis->encoder_.pos_estimate_, 0, 32, true);
-        can_setSignal<float>(txmsg, axis->encoder_.vel_estimate_, 32, 32, true);
+        can_setSignal<float>(txmsg, axis.encoder_.pos_estimate_, 0, 32, true);
+        can_setSignal<float>(txmsg, axis.encoder_.vel_estimate_, 32, 32, true);
 
         odCAN->write(txmsg);
     }
 }
 
-void CANSimple::get_sensorless_estimates_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_sensorless_estimates_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_SENSORLESS_ESTIMATES;  // heartbeat ID
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
-        static_assert(sizeof(float) == sizeof(axis->sensorless_estimator_.pll_pos_));
-        static_assert(sizeof(float) == sizeof(axis->sensorless_estimator_.vel_estimate_));
+        static_assert(sizeof(float) == sizeof(axis.sensorless_estimator_.pll_pos_));
+        static_assert(sizeof(float) == sizeof(axis.sensorless_estimator_.vel_estimate_));
 
-        can_setSignal<float>(msg, axis->sensorless_estimator_.pll_pos_, 0, 32, true);
-        can_setSignal<float>(msg, axis->sensorless_estimator_.vel_estimate_, 32, 32, true);
+        can_setSignal<float>(txmsg, axis.sensorless_estimator_.pll_pos_, 0, 32, true);
+        can_setSignal<float>(txmsg, axis.sensorless_estimator_.vel_estimate_, 32, 32, true);
 
         odCAN->write(txmsg);
     }
 }
 
-void CANSimple::get_encoder_count_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_encoder_count_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_ENCODER_COUNT;
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
-        can_setSignal<int32_t>(txmsg, axis->encoder_.shadow_count_, 0, 32, true);
-        can_setSignal<int32_t>(txmsg, axis->encoder_.count_in_cpr_, 32, 32, true);
+        can_setSignal<int32_t>(txmsg, axis.encoder_.shadow_count_, 0, 32, true);
+        can_setSignal<int32_t>(txmsg, axis.encoder_.count_in_cpr_, 32, 32, true);
         odCAN->write(txmsg);
     }
 }
 
-void CANSimple::set_input_pos_callback(Axis* axis, can_Message_t& msg) {
-    axis->controller_.input_pos_ = can_getSignal<float>(msg, 0, 32, true);
-    axis->controller_.input_vel_ = can_getSignal<int16_t>(msg, 32, 16, true, 0.001f, 0);
-    axis->controller_.input_torque_ = can_getSignal<int16_t>(msg, 48, 16, true, 0.001f, 0);
-    axis->controller_.input_pos_updated();
+void CANSimple::set_input_pos_callback( Axis& axis, const can_Message_t& msg) {
+    axis.controller_.input_pos_ = can_getSignal<float>(msg, 0, 32, true);
+    axis.controller_.input_vel_ = can_getSignal<int16_t>(msg, 32, 16, true, 0.001f, 0);
+    axis.controller_.input_torque_ = can_getSignal<int16_t>(msg, 48, 16, true, 0.001f, 0);
+    axis.controller_.input_pos_updated();
 }
 
-void CANSimple::set_input_vel_callback(Axis* axis, can_Message_t& msg) {
-    axis->controller_.input_vel_ = can_getSignal<float>(msg, 0, 32, true);
-    axis->controller_.input_torque_ = can_getSignal<float>(msg, 32, 32, true);
+void CANSimple::set_input_vel_callback( Axis& axis, const can_Message_t& msg) {
+    axis.controller_.input_vel_ = can_getSignal<float>(msg, 0, 32, true);
+    axis.controller_.input_torque_ = can_getSignal<float>(msg, 32, 32, true);
 }
 
-void CANSimple::set_input_torque_callback(Axis* axis, can_Message_t& msg) {
-    axis->controller_.input_torque_ = can_getSignal<float>(msg, 0, 32, true);
+void CANSimple::set_input_torque_callback( Axis& axis, const can_Message_t& msg) {
+    axis.controller_.input_torque_ = can_getSignal<float>(msg, 0, 32, true);
 }
 
-void CANSimple::set_controller_modes_callback(Axis* axis, can_Message_t& msg) {
-    axis->controller_.config_.control_mode = static_cast<Controller::ControlMode>(can_getSignal<int32_t>(msg, 0, 32, true));
-    axis->controller_.config_.input_mode = static_cast<Controller::InputMode>(can_getSignal<int32_t>(msg, 32, 32, true));
+void CANSimple::set_controller_modes_callback( Axis& axis, const can_Message_t& msg) {
+    axis.controller_.config_.control_mode = static_cast<Controller::ControlMode>(can_getSignal<int32_t>(msg, 0, 32, true));
+    axis.controller_.config_.input_mode = static_cast<Controller::InputMode>(can_getSignal<int32_t>(msg, 32, 32, true));
 }
 
-void CANSimple::set_vel_limit_callback(Axis* axis, can_Message_t& msg) {
-    axis->controller_.config_.vel_limit = can_getSignal<float>(msg, 0, 32, true);
+void CANSimple::set_vel_limit_callback( Axis& axis, const can_Message_t& msg) {
+    axis.controller_.config_.vel_limit = can_getSignal<float>(msg, 0, 32, true);
 }
 
-void CANSimple::start_anticogging_callback(Axis* axis, can_Message_t& msg) {
-    axis->controller_.start_anticogging_calibration();
+void CANSimple::start_anticogging_callback(const Axis& axis, const can_Message_t& msg) {
+    axis.controller_.start_anticogging_calibration();
 }
 
-void CANSimple::set_traj_vel_limit_callback(Axis* axis, can_Message_t& msg) {
-    axis->trap_traj_.config_.vel_limit = can_getSignal<float>(msg, 0, 32, true);
+void CANSimple::set_traj_vel_limit_callback( Axis& axis, const can_Message_t& msg) {
+    axis.trap_traj_.config_.vel_limit = can_getSignal<float>(msg, 0, 32, true);
 }
 
-void CANSimple::set_traj_accel_limits_callback(Axis* axis, can_Message_t& msg) {
-    axis->trap_traj_.config_.accel_limit = can_getSignal<float>(msg, 0, 32, true);
-    axis->trap_traj_.config_.decel_limit = can_getSignal<float>(msg, 32, 32, true);
+void CANSimple::set_traj_accel_limits_callback( Axis& axis, const can_Message_t& msg) {
+    axis.trap_traj_.config_.accel_limit = can_getSignal<float>(msg, 0, 32, true);
+    axis.trap_traj_.config_.decel_limit = can_getSignal<float>(msg, 32, 32, true);
 }
 
-void CANSimple::set_traj_inertia_callback(Axis* axis, can_Message_t& msg) {
-    axis->controller_.config_.inertia = can_getSignal<float>(msg, 0, 32, true);
+void CANSimple::set_traj_inertia_callback( Axis& axis, const can_Message_t& msg) {
+    axis.controller_.config_.inertia = can_getSignal<float>(msg, 0, 32, true);
 }
 
-void CANSimple::get_iq_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_iq_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_IQ;
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
-        static_assert(sizeof(float) == sizeof(axis->motor_.current_control_.Iq_setpoint));
-        static_assert(sizeof(float) == sizeof(axis->motor_.current_control_.Iq_measured));
-        can_setSignal<float>(txmsg, axis->motor_.current_control_.Iq_setpoint, 0, 32, true);
-        can_setSignal<float>(txmsg, axis->motor_.current_control_.Iq_measured, 32, 32, true);
+        static_assert(sizeof(float) == sizeof(axis.motor_.current_control_.Iq_setpoint));
+        static_assert(sizeof(float) == sizeof(axis.motor_.current_control_.Iq_measured));
+        can_setSignal<float>(txmsg, axis.motor_.current_control_.Iq_setpoint, 0, 32, true);
+        can_setSignal<float>(txmsg, axis.motor_.current_control_.Iq_measured, 32, 32, true);
 
         odCAN->write(txmsg);
     }
 }
 
-void CANSimple::get_vbus_voltage_callback(Axis* axis, can_Message_t& msg) {
+void CANSimple::get_vbus_voltage_callback(const Axis& axis, const can_Message_t& msg) {
     if (msg.rtr) {
         can_Message_t txmsg;
 
-        txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+        txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
         txmsg.id += MSG_GET_VBUS_VOLTAGE;
-        txmsg.isExt = axis->config_.can_node_id_extended;
+        txmsg.isExt = axis.config_.can_node_id_extended;
         txmsg.len = 8;
 
         uint32_t floatBytes;
@@ -311,28 +301,28 @@ void CANSimple::get_vbus_voltage_callback(Axis* axis, can_Message_t& msg) {
     }
 }
 
-void CANSimple::clear_errors_callback(Axis* axis, can_Message_t& msg) {
-    axis->clear_errors();
+void CANSimple::clear_errors_callback(Axis& axis, const can_Message_t& msg) {
+    axis.clear_errors();
 }
 
-void CANSimple::send_heartbeat(Axis* axis) {
+void CANSimple::send_heartbeat(const Axis& axis) {
     can_Message_t txmsg;
-    txmsg.id = axis->config_.can_node_id << NUM_CMD_ID_BITS;
+    txmsg.id = axis.config_.can_node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_ODRIVE_HEARTBEAT;  // heartbeat ID
-    txmsg.isExt = axis->config_.can_node_id_extended;
+    txmsg.isExt = axis.config_.can_node_id_extended;
     txmsg.len = 8;
 
     // Axis errors in 1st 32-bit value
-    txmsg.buf[0] = axis->error_;
-    txmsg.buf[1] = axis->error_ >> 8;
-    txmsg.buf[2] = axis->error_ >> 16;
-    txmsg.buf[3] = axis->error_ >> 24;
+    txmsg.buf[0] = axis.error_;
+    txmsg.buf[1] = axis.error_ >> 8;
+    txmsg.buf[2] = axis.error_ >> 16;
+    txmsg.buf[3] = axis.error_ >> 24;
 
     // Current state of axis in 2nd 32-bit value
-    txmsg.buf[4] = axis->current_state_;
-    txmsg.buf[5] = axis->current_state_ >> 8;
-    txmsg.buf[6] = axis->current_state_ >> 16;
-    txmsg.buf[7] = axis->current_state_ >> 24;
+    txmsg.buf[4] = axis.current_state_;
+    txmsg.buf[5] = axis.current_state_ >> 8;
+    txmsg.buf[6] = axis.current_state_ >> 16;
+    txmsg.buf[7] = axis.current_state_ >> 24;
     odCAN->write(txmsg);
 }
 

--- a/Firmware/communication/can_simple.cpp
+++ b/Firmware/communication/can_simple.cpp
@@ -118,7 +118,7 @@ void CANSimple::estop_callback(Axis& axis, const can_Message_t& msg) {
     axis.error_ |= Axis::ERROR_ESTOP_REQUESTED;
 }
 
-void CANSimple::get_motor_error_callback(const Axis& axis) {
+uint32_t CANSimple::get_motor_error_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_MOTOR_ERROR;  // heartbeat ID
@@ -127,10 +127,10 @@ void CANSimple::get_motor_error_callback(const Axis& axis) {
 
     can_setSignal(txmsg, axis.motor_.error_, 0, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
-void CANSimple::get_encoder_error_callback(const Axis& axis) {
+uint32_t CANSimple::get_encoder_error_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_ENCODER_ERROR;  // heartbeat ID
@@ -139,10 +139,10 @@ void CANSimple::get_encoder_error_callback(const Axis& axis) {
 
     can_setSignal(txmsg, axis.encoder_.error_, 0, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
-void CANSimple::get_sensorless_error_callback(const Axis& axis) {
+uint32_t CANSimple::get_sensorless_error_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_SENSORLESS_ERROR;  // heartbeat ID
@@ -151,7 +151,7 @@ void CANSimple::get_sensorless_error_callback(const Axis& axis) {
 
     can_setSignal(txmsg, axis.sensorless_estimator_.error_, 0, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
 void CANSimple::set_axis_nodeid_callback(Axis& axis, const can_Message_t& msg) {
@@ -166,7 +166,7 @@ void CANSimple::set_axis_startup_config_callback(Axis& axis, const can_Message_t
     // Not Implemented
 }
 
-void CANSimple::get_encoder_estimates_callback(const Axis& axis) {
+uint32_t CANSimple::get_encoder_estimates_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_ENCODER_ESTIMATES;  // heartbeat ID
@@ -179,10 +179,10 @@ void CANSimple::get_encoder_estimates_callback(const Axis& axis) {
     can_setSignal<float>(txmsg, axis.encoder_.pos_estimate_, 0, 32, true);
     can_setSignal<float>(txmsg, axis.encoder_.vel_estimate_, 32, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
-void CANSimple::get_sensorless_estimates_callback(const Axis& axis) {
+uint32_t CANSimple::get_sensorless_estimates_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_SENSORLESS_ESTIMATES;  // heartbeat ID
@@ -195,10 +195,10 @@ void CANSimple::get_sensorless_estimates_callback(const Axis& axis) {
     can_setSignal<float>(txmsg, axis.sensorless_estimator_.pll_pos_, 0, 32, true);
     can_setSignal<float>(txmsg, axis.sensorless_estimator_.vel_estimate_, 32, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
-void CANSimple::get_encoder_count_callback(const Axis& axis) {
+uint32_t CANSimple::get_encoder_count_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_ENCODER_COUNT;
@@ -207,7 +207,7 @@ void CANSimple::get_encoder_count_callback(const Axis& axis) {
 
     can_setSignal<int32_t>(txmsg, axis.encoder_.shadow_count_, 0, 32, true);
     can_setSignal<int32_t>(txmsg, axis.encoder_.count_in_cpr_, 32, 32, true);
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
 void CANSimple::set_input_pos_callback(Axis& axis, const can_Message_t& msg) {
@@ -252,7 +252,7 @@ void CANSimple::set_traj_inertia_callback(Axis& axis, const can_Message_t& msg) 
     axis.controller_.config_.inertia = can_getSignal<float>(msg, 0, 32, true);
 }
 
-void CANSimple::get_iq_callback(const Axis& axis) {
+uint32_t CANSimple::get_iq_callback(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_GET_IQ;
@@ -264,10 +264,10 @@ void CANSimple::get_iq_callback(const Axis& axis) {
     can_setSignal<float>(txmsg, axis.motor_.current_control_.Iq_setpoint, 0, 32, true);
     can_setSignal<float>(txmsg, axis.motor_.current_control_.Iq_measured, 32, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
-void CANSimple::get_vbus_voltage_callback(const Axis& axis) {
+uint32_t CANSimple::get_vbus_voltage_callback(const Axis& axis) {
     can_Message_t txmsg;
 
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
@@ -279,14 +279,14 @@ void CANSimple::get_vbus_voltage_callback(const Axis& axis) {
     static_assert(sizeof(vbus_voltage) == sizeof(floatBytes));
     can_setSignal<float>(txmsg, vbus_voltage, 0, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
 void CANSimple::clear_errors_callback(Axis& axis, const can_Message_t& msg) {
     axis.clear_errors();
 }
 
-void CANSimple::send_heartbeat(const Axis& axis) {
+uint32_t CANSimple::send_heartbeat(const Axis& axis) {
     can_Message_t txmsg;
     txmsg.id = axis.config_.can.node_id << NUM_CMD_ID_BITS;
     txmsg.id += MSG_ODRIVE_HEARTBEAT;  // heartbeat ID
@@ -296,7 +296,7 @@ void CANSimple::send_heartbeat(const Axis& axis) {
     can_setSignal(txmsg, axis.error_, 0, 32, true);
     can_setSignal(txmsg, axis.current_state_, 32, 32, true);
 
-    odCAN->write(txmsg);
+    return odCAN->write(txmsg);
 }
 
 void CANSimple::send_cyclic(Axis& axis) {
@@ -304,15 +304,15 @@ void CANSimple::send_cyclic(Axis& axis) {
 
     if (axis.config_.can.heartbeat_rate_ms > 0) {
         if ((now - axis.can_.last_heartbeat) >= axis.config_.can.heartbeat_rate_ms) {
-            send_heartbeat(axis);
-            axis.can_.last_heartbeat = now;
+            if(send_heartbeat(axis) >= 0)
+                axis.can_.last_heartbeat = now;
         }
     }
 
     if (axis.config_.can.encoder_rate_ms > 0) {
         if ((now - axis.can_.last_encoder) >= axis.config_.can.encoder_rate_ms) {
-            get_encoder_estimates_callback(axis);
-            axis.can_.last_encoder = now;
+            if(get_encoder_estimates_callback(axis) >= 0)
+                axis.can_.last_encoder = now;
         }
     }
 }

--- a/Firmware/communication/can_simple.hpp
+++ b/Firmware/communication/can_simple.hpp
@@ -6,7 +6,7 @@
 class CANSimple {
    public:
     enum {
-        MSG_CO_NMT_CTRL = 0x000,       // CANOpen NMT Message REC
+        MSG_CO_NMT_CTRL = 0x000,  // CANOpen NMT Message REC
         MSG_ODRIVE_HEARTBEAT,
         MSG_ODRIVE_ESTOP,
         MSG_GET_MOTOR_ERROR,  // Errors
@@ -34,34 +34,35 @@ class CANSimple {
         MSG_CO_HEARTBEAT_CMD = 0x700,  // CANOpen NMT Heartbeat  SEND
     };
 
-    static void handle_can_message(can_Message_t& msg);
-    static void send_heartbeat(Axis* axis);
+    static void handle_can_message(const can_Message_t& msg);
+    static void send_heartbeat(const Axis& axis);
+    static void doCommand(Axis& axis, const can_Message_t& cmd);
 
    private:
-    static void nmt_callback(Axis* axis, can_Message_t& msg);
-    static void estop_callback(Axis* axis, can_Message_t& msg);
-    static void get_motor_error_callback(Axis* axis, can_Message_t& msg);
-    static void get_encoder_error_callback(Axis* axis, can_Message_t& msg);
-    static void get_controller_error_callback(Axis* axis, can_Message_t& msg);
-    static void get_sensorless_error_callback(Axis* axis, can_Message_t& msg);
-    static void set_axis_nodeid_callback(Axis* axis, can_Message_t& msg);
-    static void set_axis_requested_state_callback(Axis* axis, can_Message_t& msg);
-    static void set_axis_startup_config_callback(Axis* axis, can_Message_t& msg);
-    static void get_encoder_estimates_callback(Axis* axis, can_Message_t& msg);
-    static void get_encoder_count_callback(Axis* axis, can_Message_t& msg);
-    static void set_input_pos_callback(Axis* axis, can_Message_t& msg);
-    static void set_input_vel_callback(Axis* axis, can_Message_t& msg);
-    static void set_input_torque_callback(Axis* axis, can_Message_t& msg);
-    static void set_controller_modes_callback(Axis* axis, can_Message_t& msg);
-    static void set_vel_limit_callback(Axis* axis, can_Message_t& msg);
-    static void start_anticogging_callback(Axis* axis, can_Message_t& msg);
-    static void set_traj_vel_limit_callback(Axis* axis, can_Message_t& msg);
-    static void set_traj_accel_limits_callback(Axis* axis, can_Message_t& msg);
-    static void set_traj_inertia_callback(Axis* axis, can_Message_t& msg);
-    static void get_iq_callback(Axis* axis, can_Message_t& msg);
-    static void get_sensorless_estimates_callback(Axis* axis, can_Message_t& msg);
-    static void get_vbus_voltage_callback(Axis* axis, can_Message_t& msg);
-    static void clear_errors_callback(Axis* axis, can_Message_t& msg);
+    static void nmt_callback(const Axis& axis, const can_Message_t& msg);
+    static void estop_callback(Axis& axis, const can_Message_t& msg);
+    static void get_motor_error_callback(const Axis& axis, const can_Message_t& msg);
+    static void get_encoder_error_callback(const Axis& axis, const can_Message_t& msg);
+    static void get_controller_error_callback(const Axis& axis, const can_Message_t& msg);
+    static void get_sensorless_error_callback(const Axis& axis, const can_Message_t& msg);
+    static void set_axis_nodeid_callback(Axis& axis, const can_Message_t& msg);
+    static void set_axis_requested_state_callback(Axis& axis, const can_Message_t& msg);
+    static void set_axis_startup_config_callback(Axis& axis, const can_Message_t& msg);
+    static void get_encoder_estimates_callback(const Axis& axis, const can_Message_t& msg);
+    static void get_encoder_count_callback(const Axis& axis, const can_Message_t& msg);
+    static void set_input_pos_callback(Axis& axis, const can_Message_t& msg);
+    static void set_input_vel_callback(Axis& axis, const can_Message_t& msg);
+    static void set_input_torque_callback(Axis& axis, const can_Message_t& msg);
+    static void set_controller_modes_callback(Axis& axis, const can_Message_t& msg);
+    static void set_vel_limit_callback(Axis& axis, const can_Message_t& msg);
+    static void start_anticogging_callback(const Axis& axis, const can_Message_t& msg);
+    static void set_traj_vel_limit_callback(Axis& axis, const can_Message_t& msg);
+    static void set_traj_accel_limits_callback(Axis& axis, const can_Message_t& msg);
+    static void set_traj_inertia_callback(Axis& axis, const can_Message_t& msg);
+    static void get_iq_callback(const Axis& axis, const can_Message_t& msg);
+    static void get_sensorless_estimates_callback(const Axis& axis, const can_Message_t& msg);
+    static void get_vbus_voltage_callback(const Axis& axis, const can_Message_t& msg);
+    static void clear_errors_callback(Axis& axis, const can_Message_t& msg);
 
     // Utility functions
     static uint32_t get_node_id(uint32_t msgID);
@@ -76,9 +77,5 @@ class CANSimple {
     //     {0x000, std::bind(&CANSimple::heartbeat_callback, this, _1)}
     // };
 };
-
-
-
-
 
 #endif

--- a/Firmware/communication/can_simple.hpp
+++ b/Firmware/communication/can_simple.hpp
@@ -38,20 +38,20 @@ class CANSimple {
     static void doCommand(Axis& axis, const can_Message_t& cmd);
 
     // Cyclic Senders
-    static uint32_t send_heartbeat(const Axis& axis);
+    static int32_t send_heartbeat(const Axis& axis);
     static void send_cyclic(Axis& axis);
 
    private:
     // Get functions (msg.rtr bit must be set)
-    static uint32_t get_motor_error_callback(const Axis& axis);
-    static uint32_t get_encoder_error_callback(const Axis& axis);
-    static uint32_t get_controller_error_callback(const Axis& axis);
-    static uint32_t get_sensorless_error_callback(const Axis& axis);
-    static uint32_t get_encoder_estimates_callback(const Axis& axis);
-    static uint32_t get_encoder_count_callback(const Axis& axis);
-    static uint32_t get_iq_callback(const Axis& axis);
-    static uint32_t get_sensorless_estimates_callback(const Axis& axis);
-    static uint32_t get_vbus_voltage_callback(const Axis& axis);
+    static int32_t get_motor_error_callback(const Axis& axis);
+    static int32_t get_encoder_error_callback(const Axis& axis);
+    static int32_t get_controller_error_callback(const Axis& axis);
+    static int32_t get_sensorless_error_callback(const Axis& axis);
+    static int32_t get_encoder_estimates_callback(const Axis& axis);
+    static int32_t get_encoder_count_callback(const Axis& axis);
+    static int32_t get_iq_callback(const Axis& axis);
+    static int32_t get_sensorless_estimates_callback(const Axis& axis);
+    static int32_t get_vbus_voltage_callback(const Axis& axis);
 
     // Set functions
     static void set_axis_nodeid_callback(Axis& axis, const can_Message_t& msg);

--- a/Firmware/communication/can_simple.hpp
+++ b/Firmware/communication/can_simple.hpp
@@ -38,20 +38,20 @@ class CANSimple {
     static void doCommand(Axis& axis, const can_Message_t& cmd);
 
     // Cyclic Senders
-    static void send_heartbeat(const Axis& axis);
+    static uint32_t send_heartbeat(const Axis& axis);
     static void send_cyclic(Axis& axis);
 
    private:
     // Get functions (msg.rtr bit must be set)
-    static void get_motor_error_callback(const Axis& axis);
-    static void get_encoder_error_callback(const Axis& axis);
-    static void get_controller_error_callback(const Axis& axis);
-    static void get_sensorless_error_callback(const Axis& axis);
-    static void get_encoder_estimates_callback(const Axis& axis);
-    static void get_encoder_count_callback(const Axis& axis);
-    static void get_iq_callback(const Axis& axis);
-    static void get_sensorless_estimates_callback(const Axis& axis);
-    static void get_vbus_voltage_callback(const Axis& axis);
+    static uint32_t get_motor_error_callback(const Axis& axis);
+    static uint32_t get_encoder_error_callback(const Axis& axis);
+    static uint32_t get_controller_error_callback(const Axis& axis);
+    static uint32_t get_sensorless_error_callback(const Axis& axis);
+    static uint32_t get_encoder_estimates_callback(const Axis& axis);
+    static uint32_t get_encoder_count_callback(const Axis& axis);
+    static uint32_t get_iq_callback(const Axis& axis);
+    static uint32_t get_sensorless_estimates_callback(const Axis& axis);
+    static uint32_t get_vbus_voltage_callback(const Axis& axis);
 
     // Set functions
     static void set_axis_nodeid_callback(Axis& axis, const can_Message_t& msg);

--- a/Firmware/communication/can_simple.hpp
+++ b/Firmware/communication/can_simple.hpp
@@ -35,47 +35,54 @@ class CANSimple {
     };
 
     static void handle_can_message(const can_Message_t& msg);
-    static void send_heartbeat(const Axis& axis);
     static void doCommand(Axis& axis, const can_Message_t& cmd);
 
+    // Cyclic Senders
+    static void send_heartbeat(const Axis& axis);
+    static void send_cyclic(Axis& axis);
+
    private:
-    static void nmt_callback(const Axis& axis, const can_Message_t& msg);
-    static void estop_callback(Axis& axis, const can_Message_t& msg);
-    static void get_motor_error_callback(const Axis& axis, const can_Message_t& msg);
-    static void get_encoder_error_callback(const Axis& axis, const can_Message_t& msg);
-    static void get_controller_error_callback(const Axis& axis, const can_Message_t& msg);
-    static void get_sensorless_error_callback(const Axis& axis, const can_Message_t& msg);
+    // Get functions (msg.rtr bit must be set)
+    static void get_motor_error_callback(const Axis& axis);
+    static void get_encoder_error_callback(const Axis& axis);
+    static void get_controller_error_callback(const Axis& axis);
+    static void get_sensorless_error_callback(const Axis& axis);
+    static void get_encoder_estimates_callback(const Axis& axis);
+    static void get_encoder_count_callback(const Axis& axis);
+    static void get_iq_callback(const Axis& axis);
+    static void get_sensorless_estimates_callback(const Axis& axis);
+    static void get_vbus_voltage_callback(const Axis& axis);
+
+    // Set functions
     static void set_axis_nodeid_callback(Axis& axis, const can_Message_t& msg);
     static void set_axis_requested_state_callback(Axis& axis, const can_Message_t& msg);
     static void set_axis_startup_config_callback(Axis& axis, const can_Message_t& msg);
-    static void get_encoder_estimates_callback(const Axis& axis, const can_Message_t& msg);
-    static void get_encoder_count_callback(const Axis& axis, const can_Message_t& msg);
     static void set_input_pos_callback(Axis& axis, const can_Message_t& msg);
     static void set_input_vel_callback(Axis& axis, const can_Message_t& msg);
     static void set_input_torque_callback(Axis& axis, const can_Message_t& msg);
     static void set_controller_modes_callback(Axis& axis, const can_Message_t& msg);
     static void set_vel_limit_callback(Axis& axis, const can_Message_t& msg);
-    static void start_anticogging_callback(const Axis& axis, const can_Message_t& msg);
     static void set_traj_vel_limit_callback(Axis& axis, const can_Message_t& msg);
     static void set_traj_accel_limits_callback(Axis& axis, const can_Message_t& msg);
     static void set_traj_inertia_callback(Axis& axis, const can_Message_t& msg);
-    static void get_iq_callback(const Axis& axis, const can_Message_t& msg);
-    static void get_sensorless_estimates_callback(const Axis& axis, const can_Message_t& msg);
-    static void get_vbus_voltage_callback(const Axis& axis, const can_Message_t& msg);
+
+    // Other functions
+    static void nmt_callback(const Axis& axis, const can_Message_t& msg);
+    static void estop_callback(Axis& axis, const can_Message_t& msg);
     static void clear_errors_callback(Axis& axis, const can_Message_t& msg);
+    static void start_anticogging_callback(const Axis& axis, const can_Message_t& msg);
+
+    static constexpr uint8_t NUM_NODE_ID_BITS = 6;
+    static constexpr uint8_t NUM_CMD_ID_BITS = 11 - NUM_NODE_ID_BITS;
 
     // Utility functions
-    static uint32_t get_node_id(uint32_t msgID);
-    static uint8_t get_cmd_id(uint32_t msgID);
+    static constexpr uint32_t get_node_id(uint32_t msgID) {
+        return (msgID >> NUM_CMD_ID_BITS);  // Upper 6 or more bits
+    };
 
-    // Fetch a specific signal from the message
-
-    // This functional way of handling the messages is neat and is much cleaner from
-    // a data security point of view, but it will require some tweaking
-    //
-    // const std::map<uint32_t, std::function<void(can_Message_t&)>> callback_map = {
-    //     {0x000, std::bind(&CANSimple::heartbeat_callback, this, _1)}
-    // };
+    static constexpr uint8_t get_cmd_id(uint32_t msgID) {
+        return (msgID & 0x01F);  // Bottom 5 bits
+    }
 };
 
 #endif

--- a/Firmware/communication/interface_can.cpp
+++ b/Firmware/communication/interface_can.cpp
@@ -36,13 +36,13 @@ void ODriveCAN::can_server_thread() {
                         break;
                 }
             }
-            HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING);
+            HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING | CAN_IT_TX_MAILBOX_EMPTY);
         } else {
             if (status == HAL_CAN_ERROR_TIMEOUT) {
                 HAL_CAN_ResetError(handle_);
                 status = HAL_CAN_Start(handle_);
                 if (status == HAL_OK)
-                    status = HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING);
+                    status = HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING | CAN_IT_TX_MAILBOX_EMPTY);
             }
         }
     }
@@ -75,7 +75,7 @@ bool ODriveCAN::start_can_server() {
 
     status = HAL_CAN_Start(handle_);
     if (status == HAL_OK)
-        status = HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING);
+        status = HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING | CAN_IT_TX_MAILBOX_EMPTY);
 
     osThreadDef(can_server_thread_def, can_server_thread_wrapper, osPriorityNormal, 0, stack_size_ / sizeof(StackType_t));
     thread_id_ = osThreadCreate(osThread(can_server_thread_def), this);
@@ -85,7 +85,7 @@ bool ODriveCAN::start_can_server() {
 }
 
 // Send a CAN message on the bus
-uint32_t ODriveCAN::write(can_Message_t &txmsg) {
+int32_t ODriveCAN::write(can_Message_t &txmsg) {
     if (HAL_CAN_GetError(handle_) == HAL_CAN_ERROR_NONE) {
         CAN_TxHeaderTypeDef header;
         header.StdId = txmsg.id;
@@ -98,8 +98,9 @@ uint32_t ODriveCAN::write(can_Message_t &txmsg) {
         uint32_t retTxMailbox = 0;
         if (HAL_CAN_GetTxMailboxesFreeLevel(handle_) > 0)
             HAL_CAN_AddTxMessage(handle_, &header, txmsg.buf, &retTxMailbox);
-
-        return retTxMailbox;
+        else
+            return -1;
+        return (int32_t)retTxMailbox;
     } else {
         return -1;
     }
@@ -168,7 +169,7 @@ void ODriveCAN::reinit_can() {
     HAL_CAN_Init(handle_);
     auto status = HAL_CAN_Start(handle_);
     if (status == HAL_OK)
-        status = HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING);
+        status = HAL_CAN_ActivateNotification(handle_, CAN_IT_RX_FIFO0_MSG_PENDING | CAN_IT_TX_MAILBOX_EMPTY);
 }
 
 void ODriveCAN::set_error(Error error) {
@@ -186,9 +187,18 @@ void ODriveCAN::send_cyclic(Axis &axis) {
     }
 }
 
-void HAL_CAN_TxMailbox0CompleteCallback(CAN_HandleTypeDef *hcan) {}
-void HAL_CAN_TxMailbox1CompleteCallback(CAN_HandleTypeDef *hcan) {}
-void HAL_CAN_TxMailbox2CompleteCallback(CAN_HandleTypeDef *hcan) {}
+void HAL_CAN_TxMailbox0CompleteCallback(CAN_HandleTypeDef *hcan) {
+    HAL_CAN_DeactivateNotification(hcan, CAN_IT_TX_MAILBOX_EMPTY);
+    osSemaphoreRelease(sem_can);
+}
+void HAL_CAN_TxMailbox1CompleteCallback(CAN_HandleTypeDef *hcan) {
+    HAL_CAN_DeactivateNotification(hcan, CAN_IT_TX_MAILBOX_EMPTY);
+    osSemaphoreRelease(sem_can);
+}
+void HAL_CAN_TxMailbox2CompleteCallback(CAN_HandleTypeDef *hcan) {
+    HAL_CAN_DeactivateNotification(hcan, CAN_IT_TX_MAILBOX_EMPTY);
+    osSemaphoreRelease(sem_can);
+}
 void HAL_CAN_TxMailbox0AbortCallback(CAN_HandleTypeDef *hcan) {}
 void HAL_CAN_TxMailbox1AbortCallback(CAN_HandleTypeDef *hcan) {}
 void HAL_CAN_TxMailbox2AbortCallback(CAN_HandleTypeDef *hcan) {}

--- a/Firmware/communication/interface_can.cpp
+++ b/Firmware/communication/interface_can.cpp
@@ -176,17 +176,17 @@ void ODriveCAN::set_error(Error error) {
 }
 // This function is called by each axis.
 // It provides an abstraction from the specific CAN protocol in use
-void ODriveCAN::send_heartbeat(Axis *axis) {
+void ODriveCAN::send_heartbeat(Axis& axis) {
     // Handle heartbeat message
-    if (axis->config_.can_heartbeat_rate_ms > 0) {
+    if (axis.config_.can_heartbeat_rate_ms > 0) {
         uint32_t now = osKernelSysTick();
-        if ((now - axis->last_heartbeat_) >= axis->config_.can_heartbeat_rate_ms) {
+        if ((now - axis.last_heartbeat_) >= axis.config_.can_heartbeat_rate_ms) {
             switch (config_.protocol) {
                 case PROTOCOL_SIMPLE:
                     CANSimple::send_heartbeat(axis);
                     break;
             }
-            axis->last_heartbeat_ = now;
+            axis.last_heartbeat_ = now;
         }
     }
 }

--- a/Firmware/communication/interface_can.cpp
+++ b/Firmware/communication/interface_can.cpp
@@ -174,20 +174,15 @@ void ODriveCAN::reinit_can() {
 void ODriveCAN::set_error(Error error) {
     error_ |= error;
 }
+
 // This function is called by each axis.
 // It provides an abstraction from the specific CAN protocol in use
-void ODriveCAN::send_heartbeat(Axis& axis) {
+void ODriveCAN::send_cyclic(Axis &axis) {
     // Handle heartbeat message
-    if (axis.config_.can_heartbeat_rate_ms > 0) {
-        uint32_t now = osKernelSysTick();
-        if ((now - axis.last_heartbeat_) >= axis.config_.can_heartbeat_rate_ms) {
-            switch (config_.protocol) {
-                case PROTOCOL_SIMPLE:
-                    CANSimple::send_heartbeat(axis);
-                    break;
-            }
-            axis.last_heartbeat_ = now;
-        }
+    switch (config_.protocol) {
+        case PROTOCOL_SIMPLE:
+            CANSimple::send_cyclic(axis);
+            break;
     }
 }
 

--- a/Firmware/communication/interface_can.hpp
+++ b/Firmware/communication/interface_can.hpp
@@ -35,7 +35,7 @@ class ODriveCAN : public ODriveIntf::CanIntf {
     volatile bool thread_id_valid_ = false;
     bool start_can_server();
     void can_server_thread();
-    void send_heartbeat(Axis& axis);
+    void send_cyclic(Axis& axis);
     void reinit_can();
 
     void set_error(Error error);

--- a/Firmware/communication/interface_can.hpp
+++ b/Firmware/communication/interface_can.hpp
@@ -35,7 +35,7 @@ class ODriveCAN : public ODriveIntf::CanIntf {
     volatile bool thread_id_valid_ = false;
     bool start_can_server();
     void can_server_thread();
-    void send_heartbeat(Axis *axis);
+    void send_heartbeat(Axis& axis);
     void reinit_can();
 
     void set_error(Error error);

--- a/Firmware/communication/interface_can.hpp
+++ b/Firmware/communication/interface_can.hpp
@@ -42,7 +42,7 @@ class ODriveCAN : public ODriveIntf::CanIntf {
 
     // I/O Functions
     uint32_t available();
-    uint32_t write(can_Message_t &txmsg);
+    int32_t write(can_Message_t &txmsg);
     bool read(can_Message_t &rxmsg);
 
     ODriveCAN::Config_t &config_;

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -417,11 +417,7 @@ interfaces:
               vel: float32
           sensorless_ramp: LockinConfig
           general_lockin: LockinConfig
-          can_node_id:
-            type: uint32
-            doc: Both axes will have the same id to start
-          can_node_id_extended: bool
-          can_heartbeat_rate_ms: uint32
+          can: CANConfig
         gate_driver:
           c_name: gate_driver_exported_
           c_is_class: False
@@ -484,6 +480,14 @@ interfaces:
       finish_on_vel: bool
       finish_on_distance: bool
       finish_on_enc_idx: bool
+
+  ODrive.Axis.CANConfig:
+    c_is_class: False
+    attributes:
+      node_id: uint32
+      is_extended: bool
+      heartbeat_rate_ms: uint32
+      encoder_rate_ms: uint32
 
   ODrive.ThermistorCurrentLimiter:
     c_is_class: False


### PR DESCRIPTION
* Use ref or const ref where applicable instead of pointers
* Switch all `get_x_callback` functions to use `can_setSignal` function instead of copying bytes manually
* Add a cyclic message handler
* Add some data types in axis to contain CANConfig and CAN runtime data per axis.
* Remove `msg` from `get_x_callback` functions by moving `if(msg.rtr)` to the switch statement