### PR TITLE
Update docker build for v0.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,22 @@ RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa
 RUN add-apt-repository ppa:jonathonf/tup
 RUN apt-get update
 RUN apt-get -y upgrade
-RUN apt-get -y install gcc-arm-embedded openocd tup python3.7 build-essential git
+RUN apt-get -y install gcc-arm-embedded openocd tup python3.7 python3-yaml python3-jinja2 python3-jsonschema build-essential git
 
 # Build step below does not know about debian's python naming schemme
 RUN ln -s /usr/bin/python3.7 /usr/bin/python
 
-# Copy the firmware tree into the container
-RUN mkdir ODrive
-COPY . ODrive
+RUN mkdir -p ODrive
 WORKDIR ODrive/Firmware
 
-# Hack around Tup's dependency on FUSE
-RUN tup generate build.sh
-RUN ./build.sh
+# Must attach the firmware tree into the container
+CMD \
+	# Regenerate python interface
+	python interface_generator_stub.py \
+	--definitions odrive-interface.yaml \
+	--template ../tools/enums_template.j2 \
+	--output ../tools/odrive/enums.py && \
+	# Hack around Tup's dependency on FUSE
+	tup init && \
+	tup generate build.sh && \
+	./build.sh

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -1,6 +1,6 @@
 function cleanup {
     echo "Removing previous build artifacts"
-    rm -rf build
+    rm -rf build/ Firmware/autogen Firmware/build Firmware/.tup
     docker rm odrive-build-cont
 }
 
@@ -13,14 +13,11 @@ function gc {
 function build {
     cleanup
 
-    echo "Building the firmware"
+    echo "Building the build-environment image"
     docker build -t odrive-build-img .
 
-    echo "Create container"
-    docker create --name odrive-build-cont odrive-build-img:latest
-
-    echo "Extract build artifacts"
-    docker cp odrive-build-cont:ODrive/Firmware/build .
+    echo "Build in container"
+    docker run -v $(pwd):/ODrive --name odrive-build-cont odrive-build-img:latest
 }
 
 function usage {


### PR DESCRIPTION
- Docker image now only contain the build environment, not the code.
  This save development time by not rebuilding docker image everytime
  source code change.
- Build by mounting repo's directory into container, build output and
  intermediate artifacts is available for inspecting if build fail
  midway.