### PR TITLE
Update CHANGELOG to mentiond gain unit changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 
 ### Changed
 * **`input_pos`, `input_vel`, `pos_estimate_linear`, `pos_estimate_circular`, are now in units of [turns] or [turns/s] instead of [counts] or [counts/s]**
+* **`pos_gain`, `vel_gain`, `vel_integrator_gain`, are now in units of [(turns/s) / turns], [Nm/(turns/s)], [Nm/(turns/s * s)] instead of [(counts/s) / counts], [A/(counts/s)], [A/((counts/s) * s)]. `pos_gain` is not really affected but previous `vel_gain` and `vel_integrator_gain` in A/(counts/s) should be multiplied by 320 to be converted to the new units.
 * `axis.motor.thermal_current_lim` has been removed. Instead a new property is available `axis.motor.effective_current_lim` which contains the effective current limit including any thermal limits.
 * `axis.motor.get_inverter_temp()`, `axis.motor.inverter_temp_limit_lower` and `axis.motor.inverter_temp_limit_upper` have been moved to seperate fet thermistor object under `axis.fet_thermistor`. `get_inverter_temp()` function has been renamed to `temp` and is now a read-only property.
 * `axis.config.counts_per_step` is now `axis.config.turns_per_step`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 ## [0.5.1] - 2020-09-27
 ### Added
 * Added motor `torque_constant`: units of torque are now [Nm] instead of just motor current.
-* Added `motor.config.torque_lim`: limit for motor torque in [Nm] units instead.
+* Added `motor.config.torque_lim`: limit for motor torque in [Nm].
 * [Motor thermistors support](docs/thermistors.md)
 * Enable/disable of thermistor thermal limits according `setting axis.<thermistor>.enabled`.
 * Introduced `odrive-interface.yaml` as a root source for the ODrive's API. `odrivetool` connects much faster as a side effect.
@@ -13,7 +13,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 
 ### Changed
 * **`input_pos`, `input_vel`, `pos_estimate_linear`, `pos_estimate_circular`, are now in units of [turns] or [turns/s] instead of [counts] or [counts/s]**
-* **`pos_gain`, `vel_gain`, `vel_integrator_gain`, are now in units of [(turns/s) / turns], [Nm/(turns/s)], [Nm/(turns/s * s)] instead of [(counts/s) / counts], [A/(counts/s)], [A/((counts/s) * s)]. `pos_gain` is not really affected but previous `vel_gain` and `vel_integrator_gain` in A/(counts/s) should be multiplied by 320 to be converted to the new units.
+* **`pos_gain`, `vel_gain`, `vel_integrator_gain`, are now in units of [(turns/s) / turns], [Nm/(turns/s)], [Nm/(turns/s * s)] instead of [(counts/s) / counts], [A/(counts/s)], [A/((counts/s) * s)].** `pos_gain` is not affected. Old values of `vel_gain` and `vel_integrator_gain` should be multiplied by `torque_constant * encoder cpr` to convert from the old units to the new units. `torque_constant` is approximately equal to 8.27 / (motor KV).
 * `axis.motor.thermal_current_lim` has been removed. Instead a new property is available `axis.motor.effective_current_lim` which contains the effective current limit including any thermal limits.
 * `axis.motor.get_inverter_temp()`, `axis.motor.inverter_temp_limit_lower` and `axis.motor.inverter_temp_limit_upper` have been moved to seperate fet thermistor object under `axis.fet_thermistor`. `get_inverter_temp()` function has been renamed to `temp` and is now a read-only property.
 * `axis.config.counts_per_step` is now `axis.config.turns_per_step`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 ## [0.5.1] - 2020-09-27
 ### Added
 * Added motor `torque_constant`: units of torque are now [Nm] instead of just motor current.
+* Added `motor.config.torque_lim`: limit for motor torque in [Nm] units instead.
 * [Motor thermistors support](docs/thermistors.md)
 * Enable/disable of thermistor thermal limits according `setting axis.<thermistor>.enabled`.
 * Introduced `odrive-interface.yaml` as a root source for the ODrive's API. `odrivetool` connects much faster as a side effect.

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -665,12 +665,15 @@ interfaces:
           pos_gain:
             type: float32
             unit: (turn/s) / turn
+            doc: units = (turn/s) / turn, default = 20
           vel_gain:
             type: float32
             unit: 'Nm/(turn/s)'
+            doc: units = 'Nm/(turn/s), default = 0.16
           vel_integrator_gain:
             type: float32
             unit: Nm/(turn/s * s)
+            doc: units = Nm/(turn/s * s), default = 0.32
           vel_limit:
             type: float32
             unit: turn/s


### PR DESCRIPTION
Changelog didn't mention changes in gains units and steps on how to update previous gains to work with new odrivetool version