### PR TITLE
Added input_mode enum values

### DIFF
--- a/GUI/src/views/Dashboard.vue
+++ b/GUI/src/views/Dashboard.vue
@@ -254,6 +254,40 @@ let odriveEnums = {
       text: "Position Control",
       value: 3,
     },
+  ],
+  input_mode: [
+    {
+      text: "Inactive",
+      value: 0
+    },
+    {
+      text: "Passthrough",
+      value: 1
+    },
+    {
+      text: "Velocity Ramp",
+      value: 2
+    },
+    {
+      text: "Position Filter",
+      value: 3
+    },
+    {
+      text: "Mix Channels",
+      value: 4
+    },
+    {
+      text: "Trapezoidal Trajectory",
+      value: 5
+    },
+    {
+      text: "Torque Ramp",
+      value: 6
+    },
+    {
+      text: "Mirror",
+      value: 7
+    }
   ]
 }
 


### PR DESCRIPTION
**Current situation**
When adding a control for `odrv0.axisX.controller.config.input_mode`, it is not treated as an enum, so no dropdown control is generated but only a numeric input.

**What this PR changed**
Now the `input_mode` is also treated as an enum and therefore a dropdown control is generated.

![image](https://user-images.githubusercontent.com/30362954/97873617-2f9a6400-1d18-11eb-8fc5-e52b59e8df9f.png)
