### PR TITLE
Support Infineon TLE5012b abs SPI encoder

### DIFF
--- a/Firmware/Drivers/STM32/stm32_spi_arbiter.hpp
+++ b/Firmware/Drivers/STM32/stm32_spi_arbiter.hpp
@@ -16,6 +16,8 @@ public:
         void (*on_complete)(void*, bool);
         void* on_complete_ctx;
         bool is_in_use = false;
+        bool split_tx_rx = false;
+        bool done_tx = false;
         struct SpiTask* next;
     };
 

--- a/Firmware/MotorControl/encoder.hpp
+++ b/Firmware/MotorControl/encoder.hpp
@@ -119,6 +119,7 @@ public:
     Stm32Gpio abs_spi_cs_gpio_;
     uint32_t abs_spi_cr1;
     uint32_t abs_spi_cr2;
+    uint16_t abs_spi_tle_dma_tx_[1] = {0x8020};
     uint16_t abs_spi_dma_tx_[1] = {0xFFFF};
     uint16_t abs_spi_dma_rx_[1];
     Stm32SpiArbiter::SpiTask spi_task_;

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -1047,6 +1047,9 @@ valuetypes:
       SpiAbsRls:
         value: 0x103
         doc: RLS Encoders
+      SpiAbsTle:
+        value: 0x104
+        doc: compatible with Infineon TLE5012b E1000
 
   ODrive.Controller.ControlMode:
     values:

--- a/tools/odrive/enums.py
+++ b/tools/odrive/enums.py
@@ -49,6 +49,7 @@ ENCODER_MODE_SPI_ABS_CUI                 = 256
 ENCODER_MODE_SPI_ABS_AMS                 = 257
 ENCODER_MODE_SPI_ABS_AEAT                = 258
 ENCODER_MODE_SPI_ABS_RLS                 = 259
+ENCODER_MODE_SPI_ABS_TLE                 = 260
 
 # ODrive.Controller.ControlMode
 CONTROL_MODE_VOLTAGE_CONTROL             = 0


### PR DESCRIPTION
This encoder is different than other SPI encoders because it uses an 3-wire SPI-compatible SSC interface.

- CS: same as normal chip select
- SCK: same as normal SPI clock
- DATA: bidirectional data line as opposed to separate MOSI / MISO
(Signal across wires is still the same as SPI)

Because of this, Infineon suggests adding a ~3.3K resistor between MOSI / MISO if you want to work with standard 4-wire SPI, but I didn't want to interfere with any other SPI devices, maybe the DRVs wouldn't be happy about it... or it could have other effects on the SPI bus... not sure.

Anyways, the SPI peripheral on stm32 can be set to use bidirectional mode (SPI_DIRECTION_1LINE) where the MOSI pin can be set to send out data, or receive data so I went with that option. 

The **spi_arbiter** was really the main part that needed to be updated to support these bidirectional SPI tasks, so I added an option to specify if a task is meant to **split_tx_rx** to encompass this.

### Signals
These show the SPI signals coming across the wires for 2 separate encoders, and the code is working fine to send the read angle value command (0x8020), then receiving the value of the angle value register.

I bumped the BaudRatePrescaler from 32 to 8 to get a much faster transaction time because I plan on using 4 of these encoders on the same ODrive (a motor encoder, and joint encoder per axis)... and I actually have that working with closed loop control and a 24:1 gear reduction, but I think I'll work on it a bit more before I open a pull request for it :)

_(My cheap logic analyzer can only sample up to 24Mhz, and the clock pulses are just past the limit, so they appear to have varying widths at around 1-2 samples)_

![image](https://user-images.githubusercontent.com/34947646/99552005-85af0e80-298a-11eb-855a-cc27ff851bd0.png)

![image](https://user-images.githubusercontent.com/34947646/99552111-a24b4680-298a-11eb-81e3-df58d52a77d5.png)

### Things to address / investigate
- In the two pictures, you can see that the entire SPI transactions are different lengths, the first is 16us, the second is 12us... I'm guessing this is because other code got scheduled in between the send/receive of the first encoder, while the second encoder transaction didn't get interrupted.
- You'll also see that the SCK line properly goes high after the first receive is complete, but not after the second transaction... I'm guessing this is because I had to disable the SPI peripheral to prevent Overruns (SCK kept pulsing past the specified 16bits, and freaked out the stm32 it seems)... some more thorough investigation in what caused the Overruns would probably be useful, but disabling SPI right after starting the DMA receive seems to work.
 

### Final Note:
Infineon's datasheet mentions that the encoders have a SLAVE_NUMBER that can be assigned 0-3 so a max of 4 encoders on one bus, but in reading the datasheet it seems that's only due to the Short PWM Code (SPC) interface. In SPC, the encoders would listen for different length pulses (based on their SLAVE_NUMBER), then send out a PWM pulse with the absolute position. SPC is is different from the SPI/SSC interface, so I have ignored it. I've been able to test multiple encoders together with the same slave number, never writing to the register, and they work completely fine... SPI only uses the CS pin so in theory you could have as many as GPIO pins available.
