### PR TITLE
Add build for MacOSX

### DIFF
--- a/Firmware/fibre-cpp/Tupfile.lua
+++ b/Firmware/fibre-cpp/Tupfile.lua
@@ -56,6 +56,9 @@ elseif string.find(machine, "x86_64.*-mingw.*") then
 elseif string.find(machine, "x86_64.*-apple-.*") then
     outname = 'libfibre-macos-x86.dylib'
     STRIP = false
+elseif string.find(machine, "arm64.*-apple-.*") then
+    outname = 'libfibre-macos-arm.dylib'
+    STRIP = false
 elseif string.find(machine, "wasm.*") then
     outname = 'libfibre-wasm.js'
     STRIP = false


### PR DESCRIPTION
This should be necessary, but not sufficient to build libfibre for arm64-apple-darwin20.1.0.

The documentation or scripts on how this is supposed to work are also not particularly obvious either.