### PR TITLE
'Current control' linked updated to read 'Torque control'

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -271,7 +271,7 @@ You can also directly control the current of the motor, which is proportional to
 - [Circular position control](#circular-position-control)
 - [Velocity control](#velocity-control)
 - [Ramped velocity control](#ramped-velocity-control)
-- [Current control](#current-control)
+- [Torque control](#Torque control)
 
 
 ### Filtered position control


### PR DESCRIPTION
The current control link pointed nowhere. Updated to torque control.