### PR TITLE
Add ignore_abs_ams_error_flag

### DIFF
--- a/Firmware/MotorControl/encoder.cpp
+++ b/Firmware/MotorControl/encoder.cpp
@@ -562,9 +562,18 @@ void Encoder::abs_spi_cb(bool success) {
     switch (mode_) {
         case MODE_SPI_ABS_AMS: {
             uint16_t rawVal = abs_spi_dma_rx_[0];
-            // check if parity is correct (even) and error flag clear
-            if (ams_parity(rawVal) || ((rawVal >> 14) & 1)) {
+            // check if parity is correct (even)
+            if (ams_parity(rawVal)) {
                 goto done;
+            }
+            // check if error flag is clear
+            if ((rawVal >> 14) & 1) {
+                spi_abs_ams_error_flag_ = true;
+                if (!config_.ignore_abs_ams_error_flag) {
+                    goto done;
+                }
+            } else {
+                spi_abs_ams_error_flag_ = false;
             }
             pos = rawVal & 0x3fff;
         } break;

--- a/Firmware/MotorControl/encoder.hpp
+++ b/Firmware/MotorControl/encoder.hpp
@@ -41,6 +41,7 @@ public:
         bool hall_polarity_calibrated = false;
         std::array<float, 6> hall_edge_phcnt = hall_edge_defaults;
         uint16_t abs_spi_cs_gpio_pin = 1;
+        bool ignore_abs_ams_error_flag = false;
         uint16_t sincos_gpio_pin_sin = 3;
         uint16_t sincos_gpio_pin_cos = 4;
 
@@ -110,6 +111,7 @@ public:
     float calib_scan_response_ = 0.0f; // debug report from offset calib
     int32_t pos_abs_ = 0;
     float spi_error_rate_ = 0.0f;
+    bool spi_abs_ams_error_flag_ = false;
 
     OutputPort<float> pos_estimate_ = 0.0f; // [turn]
     OutputPort<float> vel_estimate_ = 0.0f; // [turn/s]

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -970,6 +970,11 @@ interfaces:
               ODrive then it does not output an index pulse.
           ABS_SPI_TIMEOUT:
           ABS_SPI_COM_FAIL:
+            doc: |
+              The communication with the encoder failed, or the encoder set the error flag to true.
+              It is possible that the wire to the encoder is too long.
+              If this error doesn't go away with clear_errors, you can try to set 
+              `<axis>.encoder.ignore_abs_ams_error_flag` to `True`.
           ABS_SPI_NOT_READY:
           HALL_NOT_CALIBRATED_YET:
       is_ready: readonly bool
@@ -989,6 +994,7 @@ interfaces:
       calib_scan_response: readonly float32
       pos_abs: int32
       spi_error_rate: readonly float32
+      spi_abs_ams_error_flag: readonly bool
       config:
         c_is_class: False
         attributes:
@@ -998,6 +1004,7 @@ interfaces:
           use_index_offset: bool
           find_idx_on_lockin_only: {type: bool, c_setter: set_find_idx_on_lockin_only}
           abs_spi_cs_gpio_pin: {type: uint16, c_setter: set_abs_spi_cs_gpio_pin, doc: Make sure that the GPIO is in `GPIO_MODE_DIGITAL`.}
+          ignore_abs_ams_error_flag: {type: bool, doc: If this is true, errors reported by the encoder will be ignored. Set this to true if you get ENCODER_ERROR_ABS_SPI_COM_FAIL errors and they do not disappear with clear_errors. You can still check for the error flag with `<axis>.encoder.spi_abs_ams_error_flag`.}
           cpr: int32
           phase_offset: int32
           phase_offset_float: float32


### PR DESCRIPTION
This adds an option to disable the errorflag check for abs_ams encoders.
See also here:
https://discourse.odriverobotics.com/t/clarification-on-spi-encoders/6451
