### PR TITLE
Update firmware version prerelease status resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Features
 Please add a note of your changes below this heading if you make a Pull Request.
+* Fix python DFU firmware version prerelease status resolution to use correct attribute
 
 # Releases
 ## [0.5.3] - unreleased

--- a/tools/odrive/dfu.py
+++ b/tools/odrive/dfu.py
@@ -303,7 +303,7 @@ def update_device(device, firmware, logger, cancellation_token):
     fw_version_major = device.fw_version_major if hasattr(device, 'fw_version_major') else 0
     fw_version_minor = device.fw_version_minor if hasattr(device, 'fw_version_minor') else 0
     fw_version_revision = device.fw_version_revision if hasattr(device, 'fw_version_revision') else 0
-    fw_version_prerelease = device.fw_version_prerelease if hasattr(device, 'fw_version_prerelease') else True
+    fw_version_prerelease = device.fw_version_unreleased != 0 if hasattr(device, 'fw_version_unreleased') else True
     fw_version = (fw_version_major, fw_version_minor, fw_version_revision, fw_version_prerelease)
 
     print("Found ODrive {} ({}) with firmware {}{}".format(


### PR DESCRIPTION
Update `odrive.dfu.update_device` firmware version prerelease status resolution to use `version_unreleased` attribute, as opposed to using the `version_prerelease` attribute (no longer a valid attribute). Backwards compatibility is ensured.