### PR TITLE
Fixes hanging after exit when thread started

### DIFF
--- a/tools/odrive/__init__.py
+++ b/tools/odrive/__init__.py
@@ -45,7 +45,7 @@ def find_any(path=default_search_path, serial_number=None,
             channel_termination_token.wait()
             discovery.stop()
     
-    threading.Thread(target=domain_thread).start()
+    threading.Thread(target=domain_thread, daemon=True).start()
 
     try:
         done_signal.wait(timeout=timeout)


### PR DESCRIPTION
Fixes https://github.com/odriverobotics/ODrive/issues/586

Answer from: http://skybert.net/python/python-pytest-hangs-forever