### PR TITLE
Fixed generation of version.c file to please the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR ODrive/Firmware
 # Must attach the firmware tree into the container
 CMD \
 	# Regenerate python interface
+	mkdir ../Firmware/autogen && \
 	python interface_generator_stub.py \
 	--definitions odrive-interface.yaml \
 	--template ../tools/enums_template.j2 \
@@ -26,6 +27,7 @@ CMD \
 	--definitions odrive-interface.yaml \
 	--template ../tools/arduino_enums_template.j2 \
 	--output ../Arduino/ODriveArduino/ODriveEnums.h && \
+	python ../tools/odrive/version.py --output ../Firmware/autogen/version.c && \
 	# Hack around Tup's dependency on FUSE
 	tup init && \
 	tup generate build.sh && \


### PR DESCRIPTION
Docker was not building anymore. Failing with this error:
```
tup error: Explicitly named file 'version.c' not found in subdir 'autogen'
tup error [string "builtin"]:89: Error parsing input list
stack traceback:
	[C]: in field 'definerule'
	[string "builtin"]:89: in field 'frule'
	[string "Tupfile.lua"]:44: in function 'compile'
	[string "Tupfile.lua"]:433: in main chunk
```
Added generation of this file to the build commands. 
Just out of curiosity: Why are we not using ```make``` in the docker build??