### PR TITLE
Add version.c generation to dockerbuild and actions

### DIFF
--- a/.github/actions/release-firmware/action.yml
+++ b/.github/actions/release-firmware/action.yml
@@ -19,6 +19,9 @@ runs:
 
         cd ${{ github.workspace }}/Firmware
 
+        mkdir -p autogen
+        python ../tools/odrive/version.py --output autogen/version.c
+
         echo "CONFIG_STRICT=true" > tup.config
         echo "CONFIG_BOARD_VERSION=${{ inputs.board_version }}" >> tup.config
         tup init

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ WORKDIR ODrive/Firmware
 
 # Must attach the firmware tree into the container
 CMD \
+	# Regenerate autogen/version.c
+	mkdir -p autogen && \
+	python ../tools/odrive/version.py \
+	--output autogen/version.c && \
 	# Regenerate python interface
 	python interface_generator_stub.py \
 	--definitions odrive-interface.yaml \


### PR DESCRIPTION
Actually this is fix to c5720564d74b47359a2dab45aa315ab6c0550a0e that have broken `dockerbuild.sh` and seems to broke GitHub Action.

Reason is that c5720564d74b47359a2dab45aa315ab6c0550a0e removes generating `autogen/version.c` from `Tupfile.lua` and adds it to `Makefile`. But `dockerbuild.sh` and GitHub Action does not use `Makefile` so they can't find `autogen/version.c`

If `dockerbuild.sh` or GitHub Action works I think the reason is that they have old `autogen/version.c` in cache. Don't know about GitHub Action but `dockerbuild.sh` doesn't work at this moment from clear repo