### PR TITLE
Fix race condition in trap traj control

### DIFF
--- a/Firmware/MotorControl/controller.cpp
+++ b/Firmware/MotorControl/controller.cpp
@@ -209,7 +209,7 @@ bool Controller::update() {
             if (axis_->trap_traj_.t_ > axis_->trap_traj_.Tf_) {
                 // Drop into position control mode when done to avoid problems on loop counter delta overflow
                 config_.control_mode = CONTROL_MODE_POSITION_CONTROL;
-                pos_setpoint_ = input_pos_;
+                pos_setpoint_ = axis_->trap_traj_.Xf_;
                 vel_setpoint_ = 0.0f;
                 torque_setpoint_ = 0.0f;
                 trajectory_done_ = true;


### PR DESCRIPTION
Actually there is a race condition at [controller.cpp:212](https://github.com/odriverobotics/ODrive/blob/68d923e8a8b60e21308cba41a66d0ca18c84dd91/Firmware/MotorControl/controller.cpp#L212):
1. When execution is somewhere in lines 206-211 this function can be interrupted (for example by CAN Bus) and `input_pos_` can be updated.
2. Then it will be immediately set into the `pos_setpoint_` and motor will go there by PID instead of trap traj.
3. On the next iteration `move_to_pos(input_pos_)` will plan next trajectory from `pos_setpoint_` and immediately complete it because `pos_setpoint_ == goal_point` so motor will continue moving by PID

To catch this case this part of code can be commented, then problem line will be executed in each iteration when trajectory have been completed and it is very easy to catch the bug:
```
if (trajectory_done_)
    break;
```