### PR TITLE
Can example patch

### DIFF
--- a/docs/control.rst
+++ b/docs/control.rst
@@ -107,7 +107,7 @@ The three (starting) values are:
 
     .. code:: iPython
         
-        odrv0.axis0..controller.config.vel_gain = 0.16
+        odrv0.axis0.controller.config.vel_gain = 0.16
 
 * vel_integrator_gain [Nm/((turn/s) * s)]:
 

--- a/tools/can_example.py
+++ b/tools/can_example.py
@@ -18,7 +18,7 @@ print("Waiting for calibration to finish...")
 while True:
     msg = bus.recv()
     if msg.arbitration_id == (axisID << 5 | 0x01):
-        current_state = msg.data[4] | msg.data[5] << 8 | msg.data[6] << 16 | msg.data[7] << 24
+        current_state = msg.data[4]
         if current_state == 0x1:
             print("\nAxis has returned to Idle state.")
             break


### PR DESCRIPTION
The documentation, CAN doc file, and firmware all indicate that the current state is only one byte of the heartbeat message. The `can_example.py` file used to read four bytes as the state on line 21, but only one byte on line 49. This PR adjusts line 21 so that it only uses one byte, making the example work. Otherwise, it incorrectly reads the flags that occupy the next three bytes as part of the state, which can cause the idle state to never be recognized.