### PR TITLE
Fixes three things Hangprinter needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 * Ensure endstops update before being checked for errors, to prevent [#625](https://github.com/odriverobotics/ODrive/issues/625)
 * Reset trajectory_done_ during homing to ensure a new trajectory is actually computed [#634](https://github.com/odriverobotics/ODrive/issues/634)
 * Use `input_xxx` as a DC offset in tuning mode
+* Syncs `steps_` with input pos when set explicitly via CAN.
 
 # Releases
 ## [0.5.4] - 2021-10-12

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -295,9 +295,7 @@ bool Axis::start_closed_loop_control() {
                 return false;
             } else {
                 controller_.pos_setpoint_ = *pos_init;
-                controller_.input_pos_ = *pos_init;
-                float range = controller_.config_.circular_setpoint_range;
-                steps_ = (int64_t)(fmodf_pos(*pos_init, range) / range * controller_.config_.steps_per_circular_range);
+                controller_.set_input_pos_and_steps(*pos_init);
             }
         }
         controller_.input_pos_updated();

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -288,15 +288,7 @@ bool Axis::start_closed_loop_control() {
 
         // To avoid any transient on startup, we intialize the setpoint to be the current position
         if (controller_.config_.control_mode >= Controller::CONTROL_MODE_POSITION_CONTROL) {
-            std::optional<float> pos_init = (controller_.config_.circular_setpoints ?
-                                    controller_.pos_estimate_circular_src_ :
-                                    controller_.pos_estimate_linear_src_).any();
-            if (!pos_init.has_value()) {
-                return false;
-            } else {
-                controller_.pos_setpoint_ = *pos_init;
-                controller_.set_input_pos_and_steps(*pos_init);
-            }
+            controller_.set_setpoint_to_estimate();
         }
         controller_.input_pos_updated();
 

--- a/Firmware/MotorControl/controller.cpp
+++ b/Firmware/MotorControl/controller.cpp
@@ -90,7 +90,7 @@ bool Controller::anticogging_calibration(float pos_estimate, float vel_estimate)
 void Controller::set_input_pos_and_steps(float const pos) {
     input_pos_ = pos;
     float const range = config_.circular_setpoint_range;
-    axis_->steps_ = (int64_t)(wrap_pm(pos, range) / range * config_.steps_per_circular_range);
+    axis_->steps_ = (int64_t)(fmodf_pos(pos, range) / range * config_.steps_per_circular_range);
 }
 
 void Controller::update_filter_gains() {

--- a/Firmware/MotorControl/controller.cpp
+++ b/Firmware/MotorControl/controller.cpp
@@ -97,6 +97,19 @@ void Controller::set_input_pos_and_steps(float const pos) {
     }
 }
 
+bool Controller::set_setpoint_to_estimate() {
+    std::optional<float> estimate = (config_.circular_setpoints ?
+                            pos_estimate_circular_src_ :
+                            pos_estimate_linear_src_).any();
+    if (!estimate.has_value()) {
+        return false;
+    }
+
+    pos_setpoint_ = *estimate;
+    set_input_pos_and_steps(*estimate);
+    return true;
+}
+
 
 void Controller::update_filter_gains() {
     float bandwidth = std::min(config_.input_filter_bandwidth, 0.25f * current_meas_hz);

--- a/Firmware/MotorControl/controller.cpp
+++ b/Firmware/MotorControl/controller.cpp
@@ -87,6 +87,12 @@ bool Controller::anticogging_calibration(float pos_estimate, float vel_estimate)
     }
 }
 
+void Controller::set_input_pos_and_steps(float const pos) {
+    input_pos_ = pos;
+    float const range = config_.circular_setpoint_range;
+    axis_->steps_ = (int64_t)(wrap_pm(pos, range) / range * config_.steps_per_circular_range);
+}
+
 void Controller::update_filter_gains() {
     float bandwidth = std::min(config_.input_filter_bandwidth, 0.25f * current_meas_hz);
     input_filter_ki_ = 2.0f * bandwidth;  // basic conversion to discrete time

--- a/Firmware/MotorControl/controller.hpp
+++ b/Firmware/MotorControl/controller.hpp
@@ -81,6 +81,7 @@ public:
     bool anticogging_calibration(float pos_estimate, float vel_estimate);
 
     void set_input_pos_and_steps(float pos);
+    bool set_setpoint_to_estimate();
 
     void update_filter_gains();
     bool update();
@@ -124,7 +125,7 @@ public:
     OutputPort<float> torque_output_ = 0.0f;
 
     // custom setters
-    void set_input_pos(float value) { input_pos_ = value; input_pos_updated(); }
+    void set_input_pos(float value) { set_input_pos_and_steps(value); input_pos_updated(); }
 };
 
 #endif // __CONTROLLER_HPP

--- a/Firmware/MotorControl/controller.hpp
+++ b/Firmware/MotorControl/controller.hpp
@@ -80,6 +80,8 @@ public:
     void start_anticogging_calibration();
     bool anticogging_calibration(float pos_estimate, float vel_estimate);
 
+    void set_input_pos_and_steps(float pos);
+
     void update_filter_gains();
     bool update();
 

--- a/Firmware/communication/can/can_simple.cpp
+++ b/Firmware/communication/can/can_simple.cpp
@@ -272,14 +272,7 @@ void CANSimple::set_controller_modes_callback(Axis& axis, const can_Message_t& m
 
     Controller::ControlMode const mode = static_cast<Controller::ControlMode>(can_getSignal<int32_t>(msg, 0, 32, true));
     if (mode == Controller::CONTROL_MODE_POSITION_CONTROL) {
-        float estimate = 0.0f;
-        if (axis.controller_.config_.circular_setpoints) {
-            estimate = axis.encoder_.pos_circular_.any().value_or(0.0f);
-        } else {
-            estimate = axis.encoder_.pos_estimate_.any().value_or(0.0f);
-        }
-
-        axis.controller_.set_input_pos_and_steps(estimate);
+        axis.controller_.set_setpoint_to_estimate();
     }
 
     axis.controller_.config_.control_mode = static_cast<Controller::ControlMode>(mode);

--- a/Firmware/communication/can/can_simple.cpp
+++ b/Firmware/communication/can/can_simple.cpp
@@ -253,7 +253,7 @@ bool CANSimple::get_encoder_count_callback(const Axis& axis) {
 }
 
 void CANSimple::set_input_pos_callback(Axis& axis, const can_Message_t& msg) {
-    axis.controller_.input_pos_ = can_getSignal<float>(msg, 0, 32, true);
+    axis.controller_.set_input_pos_and_steps(can_getSignal<float>(msg, 0, 32, true));
     axis.controller_.input_vel_ = can_getSignal<int16_t>(msg, 32, 16, true, 0.001f, 0);
     axis.controller_.input_torque_ = can_getSignal<int16_t>(msg, 48, 16, true, 0.001f, 0);
     axis.controller_.input_pos_updated();

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -1013,6 +1013,7 @@ interfaces:
         c_setter: set_input_pos
         doc: |
           Set the desired position of the axis.  Only valid in `CONTROL_MODE_POSITION_CONTROL`.startup.
+          Also updates the step count.
           In `INPUT_MODE_TUNING`, this acts as a DC offset for the position sine wave.
       input_vel:
         type: float32
@@ -1610,6 +1611,7 @@ valuetypes:
         doc: |
           Uses the inner torque loop, the velocity control loop, and the outer position control loop.
           Use `input_pos` to command desired position, `input_vel` to command velocity feed-forward, and `input_torque` for torque feed-forward.
+        c_setter: set_setpoint_to_estimate
 
   ODrive.Controller.InputMode:
     values:


### PR DESCRIPTION
... because otherwise, the effect of the callback is canceled by an
assignment in the main update() loop, that calculates input_pos
based on steps_, if we're in step/dir mode.

- Fixes a steps_ underflow/wrapping bug