### PR TITLE
Fix race condition in homing behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased Features
 Please add a note of your changes below this heading if you make a Pull Request.
 
+### Fixed
+
+* Fixed race condition in homing sequence that was causing strange behaviour
+
 # Releases
 ## [0.5.5] - 2022-08-11
 

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -354,9 +354,6 @@ bool Axis::run_closed_loop_control_loop() {
 // Slowly drive in the negative direction at homing_speed until the min endstop is pressed
 // When pressed, set the linear count to the offset (default 0), and then go to position 0
 bool Axis::run_homing() {
-    Controller::ControlMode stored_control_mode = controller_.config_.control_mode;
-    Controller::InputMode stored_input_mode = controller_.config_.input_mode;
-
     // TODO: theoretically this check should be inside the update loop,
     // otherwise someone could disable the endstop while homing is in progress.
     if (!min_endstop_.config_.enabled) {
@@ -434,8 +431,6 @@ bool Axis::run_homing() {
     // Force encoder estimate to update
     osDelay(1);
 
-    controller_.config_.control_mode = stored_control_mode;
-    controller_.config_.input_mode = stored_input_mode;
     homing_.is_homed = true;
 
     return check_for_errors();
@@ -545,9 +540,13 @@ void Axis::run_state_machine_loop() {
             } break;
 
             case AXIS_STATE_HOMING: {
-                //if (odrv.any_error())
-                //    goto invalid_state_label;
+                Controller::ControlMode stored_control_mode = controller_.config_.control_mode;
+                Controller::InputMode stored_input_mode = controller_.config_.input_mode;
+                
                 status = run_homing();
+
+                controller_.config_.control_mode = stored_control_mode;
+                controller_.config_.input_mode = stored_input_mode;
             } break;
 
             case AXIS_STATE_ENCODER_OFFSET_CALIBRATION: {

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -431,6 +431,9 @@ bool Axis::run_homing() {
     controller_.vel_setpoint_ = 0.0f;
     controller_.input_pos_updated();
 
+    // Force encoder estimate to update
+    osDelay(1);
+
     controller_.config_.control_mode = stored_control_mode;
     controller_.config_.input_mode = stored_input_mode;
     homing_.is_homed = true;

--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -424,9 +424,11 @@ bool Axis::run_homing() {
         return false;
     }
 
-    // Set the current position to 0.
-    encoder_.set_linear_count(0);
-    controller_.input_pos_ = 0;
+    // Set the current position to 0, the target to zero, and make sure we're path planning from 0 to 0
+    encoder_.set_linear_count(0); 
+    controller_.input_pos_ = 0.0f;
+    controller_.pos_setpoint_ = 0.0f;
+    controller_.vel_setpoint_ = 0.0f;
     controller_.input_pos_updated();
 
     controller_.config_.control_mode = stored_control_mode;

--- a/Firmware/MotorControl/endstop.hpp
+++ b/Firmware/MotorControl/endstop.hpp
@@ -18,7 +18,6 @@ class Endstop {
         void set_debounce_ms(uint32_t value) { debounce_ms = value; parent->apply_config(); }
     };
 
-    Endstop() {}
 
     Endstop::Config_t config_;
     Axis* axis_ = nullptr;


### PR DESCRIPTION
- Sets `input_pos` and `pos_setpoint` = 0.0 after moving to the final homed position
- Add a 1ms delay to after `set_linear_count(0)` to allow `pos_estimate` to update so that we don't reset `input_pos` when transitioning back into closed loop

- [ ] Add to change log

Tested by user with industrial robot with optical homing switches.
![image](https://user-images.githubusercontent.com/3612694/188551707-3d1c04b9-73d4-482a-a4f2-4993c804b83c.png)

![image](https://user-images.githubusercontent.com/3612694/188551780-4475074f-a406-4663-b899-f797fbd94f11.png)
