### PR TITLE
Rebased to docs-v0.5.6, changed hard link to reference in hoverboard.…

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -256,7 +256,7 @@ Once the error(s) have been identified and corrected, run :code:`odrv0.clear_err
 
 .. admonition:: Working on a hoverboard?
 
-    There is a :ref:`separate guide <hoverboard-doc>` specifically for hoverboard motors
+    There is a :ref:`separate guide <hoverboard-doc>` specifically for hoverboard motors with RC PWM input and the built-in hall sensors.
 
 
 Setting the Limits
@@ -279,7 +279,7 @@ Current limit
 
         odrv0.axis0.motor.config.current_lim = val
 
-    Once you have tuned the ODrive, you can increase this to 60A to increase performance.   
+    Once you have tuned the ODrive, you can increase this to your motor's maximum current, up to 60A, to increase performance.   
 
     .. dropdown:: Need more than 60A?
 
@@ -419,6 +419,7 @@ Motor Thermistor
 If using motor thermistor please see the :ref:`thermistors <thermistor-doc>` page for setup.
 
 
+.. _encoder-config:
 
 Encoder Configuration
 --------------------------------------------------------------------------------

--- a/docs/hoverboard.rst
+++ b/docs/hoverboard.rst
@@ -97,7 +97,9 @@ If you can't perform this test, a typical value is 16.
   odrv0.axis0.motor.config.current_control_bandwidth = 100
   odrv0.axis0.motor.config.torque_constant = 8.27 / <measured KV>
 
-
+Hall Sensor Configuration
+-------------------------------------------------------------------------------
+If using a hoverboard motor with an encoder attached instead of the internal hall sensors, use the encoder configuration section of the :ref:`Getting Started <encoder-config>` guide.
 If you set the encoder to hall mode (instead of incremental). 
 See the :ref:`pinout <encoders-hall-effect>` for instructions on how to plug in the hall feedback.
 The hall feedback has 6 states for every pole pair in the motor. 
@@ -132,6 +134,8 @@ Lets also start in velocity control mode since that is probably what you want fo
   odrv0.axis0.controller.config.vel_limit = 10
   odrv0.axis0.controller.config.control_mode = CONTROL_MODE_VELOCITY_CONTROL
 
+Calibration and Powering the Motor
+-------------------------------------------------------------------------------
 
 In the next step we are going to start powering the motor and so we want to make sure that some of the above settings that require a reboot are applied first.
 


### PR DESCRIPTION
…rst, added reference to getting-started.rst for Encoder Configuration, clarified statement about changing current limit to 60A, clarified hoverboard guide settings relateding to use without an encoder.