### PR TITLE
Add option to ignore endstops during startup

### DIFF
--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -153,9 +153,9 @@ bool Axis::do_checks(uint32_t timestamp) {
     motor_.do_checks(timestamp);
 
     // Check for endstop presses
-    if (min_endstop_.config_.enabled && min_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING)) {
+    if (min_endstop_.config_.enabled && min_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING) && !(min_endstop_.config_.ignore_during_startup && current_state_ == AXIS_STATE_UNDEFINED)) {
         error_ |= ERROR_MIN_ENDSTOP_PRESSED;
-    } else if (max_endstop_.config_.enabled && max_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING)) {
+    } else if (max_endstop_.config_.enabled && max_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING) && !(max_endstop_.config_.ignore_during_startup && current_state_ == AXIS_STATE_UNDEFINED)) {
         error_ |= ERROR_MAX_ENDSTOP_PRESSED;
     }
 

--- a/Firmware/MotorControl/endstop.hpp
+++ b/Firmware/MotorControl/endstop.hpp
@@ -10,6 +10,7 @@ class Endstop {
         uint16_t gpio_num = 0;
         bool enabled = false;
         bool is_active_high = false;
+        bool ignore_during_startup = false;
 
         // custom setters
         Endstop* parent = nullptr;

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -1409,6 +1409,7 @@ interfaces:
           enabled: {type: bool, c_setter: set_enabled}
           offset: {type: float32, unit: turns}
           is_active_high: bool
+          ignore_during_startup: bool
           debounce_ms: {type: uint32, c_setter: set_debounce_ms}
 
   ODrive.MechanicalBrake:


### PR DESCRIPTION
This is useful for devices where the endstop is pressed while power is off, due to gravity, springs, or otherwise. When the ODrive initially starts up, it sees the limit switch(es) pressed and disarms the motor(s) immediately. With this setting enabled, the limit switch will not cause the motor to disarm during inital startup, making the `odrive.axis*.config.startup_*` flags useful again.

As an example of a potential use case, I'm building a flight simulator, where the pod the rider sits is supported on 6 linear actuators. Each actuator has a lower endstop (`odrive.axis*.min_endstop`) and is configured with `startup_encoder_index_search`, `startup_homing`, and `startup_closed_loop_control` all enabled. However, currently, when powering on the machine, it needs 3 people to help hold the weight of the pod and a 4th operator to manually rotate the motors to lift each actuator off the endstops. Obviously, this is not ideal, and while there are potential solutions that we've thought of, the simplest (and, in my opinion, safest) is to just have it allow the startup sequence to run while the endstops are pressed. The settings for `startup_encoder_index_search` can be configured to make the actuators always move up, and then `startup_homing` takes over and moves the actuators away from the endstops.

If there are any concerns around this PR, I'd be happy to discuss them. As far as I can tell, using `AXIS_STATE_UNDEFINED` as a flag for initial startup seems to be correct, as [it's used for that purpose in axis.cpp#458](https://github.com/odriverobotics/ODrive/blob/6c3cefdeacce600ba4524f4adc5fd634c7bebd18/Firmware/MotorControl/axis.cpp#L458) and is used as the [condition for the `is_booting()` variable in main.cpp#45-47](https://github.com/odriverobotics/ODrive/blob/6c3cefdeacce600ba4524f4adc5fd634c7bebd18/Firmware/MotorControl/main.cpp#L45). 